### PR TITLE
Extend BlockBasedTableOptions to indicate the use of learned index

### DIFF
--- a/include/rocksdb/table.h
+++ b/include/rocksdb/table.h
@@ -130,7 +130,7 @@ struct BlockBasedTableOptions {
     // this index type is enabled, RocksDB cannot read index block with
     // kBinarySearch etc.
     // Note: Using this index type may ignore other options related to other
-    // index types.
+    // index types, inc. index_shortening.
     kLearnedIndexWithPLR = 0x04,
   };
 

--- a/include/rocksdb/table.h
+++ b/include/rocksdb/table.h
@@ -119,6 +119,19 @@ struct BlockBasedTableOptions {
     // slice, and you need to call Valid()/status() afterwards.
     // TODO(kolmike): Fix it.
     kBinarySearchWithFirstKey = 0x03,
+
+    // Index block stores the parameters of a PLR learned model. The PLR model
+    // takes a key as input and outputs a data block number with an error bound.
+    // If this index type is enabled, an additional metablock is required
+    // storing an array of block_size indicating the valid size of each data
+    // block.
+    //
+    // Note: This index type may not ensure backward-compatibility, i.e. if
+    // this index type is enabled, RocksDB cannot read index block with
+    // kBinarySearch etc.
+    // Note: Using this index type may ignore other options related to other
+    // index types.
+    kLearnedIndexWithPLR = 0x04,
   };
 
   IndexType index_type = kBinarySearch;

--- a/table/block_based/block_based_table_factory.cc
+++ b/table/block_based/block_based_table_factory.cc
@@ -198,7 +198,7 @@ BlockBasedTableFactory::BlockBasedTableFactory(
     table_options_.partition_filters = false;
   }
   if (table_options_.index_type == BlockBasedTableOptions::kLearnedIndexWithPLR) {
-    // TODO: Add block based table factory related logic in the future
+    // TODO(fyp): Add block based table factory related logic in the future
   }
 }
 
@@ -290,7 +290,7 @@ Status BlockBasedTableFactory::SanitizeOptions(
         "unordered_write");
   }
   if (table_options_.index_type == BlockBasedTableOptions::kLearnedIndexWithPLR) {
-    // TODO: Add sanitization-related logic for PLR index type, if any, in the future
+    // TODO(fyp): Add sanitization-related logic for PLR index type, if any, in the future
   }
   return Status::OK();
 }

--- a/table/block_based/block_based_table_factory.cc
+++ b/table/block_based/block_based_table_factory.cc
@@ -197,6 +197,9 @@ BlockBasedTableFactory::BlockBasedTableFactory(
     // We do not support partitioned filters without partitioning indexes
     table_options_.partition_filters = false;
   }
+  if (table_options_.index_type == BlockBasedTableOptions::kLearnedIndexWithPLR) {
+    // TODO: Add block based table factory related logic in the future
+  }
 }
 
 Status BlockBasedTableFactory::NewTableReader(
@@ -285,6 +288,9 @@ Status BlockBasedTableFactory::SanitizeOptions(
     return Status::InvalidArgument(
         "max_successive_merges larger than 0 is currently inconsistent with "
         "unordered_write");
+  }
+  if (table_options_.index_type == BlockBasedTableOptions::kLearnedIndexWithPLR) {
+    // TODO: Add sanitization-related logic for PLR index type, if any, in the future
   }
   return Status::OK();
 }

--- a/table/block_based/block_based_table_factory.cc
+++ b/table/block_based/block_based_table_factory.cc
@@ -198,7 +198,7 @@ BlockBasedTableFactory::BlockBasedTableFactory(
     table_options_.partition_filters = false;
   }
   if (table_options_.index_type == BlockBasedTableOptions::kLearnedIndexWithPLR) {
-    // TODO(fyp): Add block based table factory related logic in the future
+    // TODO(fyp): Add block based table factory related logic if any
   }
 }
 
@@ -289,8 +289,15 @@ Status BlockBasedTableFactory::SanitizeOptions(
         "max_successive_merges larger than 0 is currently inconsistent with "
         "unordered_write");
   }
-  if (table_options_.index_type == BlockBasedTableOptions::kLearnedIndexWithPLR) {
-    // TODO(fyp): Add sanitization-related logic for PLR index type, if any, in the future
+  if (table_options_.index_type == 
+          BlockBasedTableOptions::kLearnedIndexWithPLR) {
+    // TODO(fyp): Add sanitization-related logic for PLR index type, if any
+    if (table_options_.index_block_restart_interval != 1) {
+      return Status::InvalidArgument(
+        "index_block_restart_interval is not configurable for "
+        "index type kLearnedIndexWithPLR, it should follow the default "
+        "value 1 and will not instead be silently converted");
+    }
   }
   return Status::OK();
 }

--- a/table/block_based/block_based_table_reader.cc
+++ b/table/block_based/block_based_table_reader.cc
@@ -795,15 +795,16 @@ class PLRIndexReader: public BlockBasedTable::IndexReader {
     static Status Create() {
       assert(false);
       std::string error_message =
-          "TODO(fyp): " + ToString(rep_->index_type);
+          "TODO(fyp): PLRIndexReader";
       return Status::InvalidArgument(error_message.c_str());
     }
-    virtual ~IndexReader() = default;
+    // virtual ~IndexReader() = default;
 
     InternalIteratorBase<IndexValue>* NewIterator(
         const ReadOptions& read_options, bool disable_prefix_seek,
         IndexBlockIter* iter, GetContext* get_context,
         BlockCacheLookupContext* lookup_context) {
+      read_options; disable_prefix_seek; iter; get_context; lookup_context;
       return nullptr;
     }
 
@@ -812,7 +813,7 @@ class PLRIndexReader: public BlockBasedTable::IndexReader {
     }
     
     void CacheDependencies(bool /* pin */) {}
-}
+};
 
 void BlockBasedTable::UpdateCacheHitMetrics(BlockType block_type,
                                             GetContext* get_context,

--- a/table/block_based/block_based_table_reader.cc
+++ b/table/block_based/block_based_table_reader.cc
@@ -787,6 +787,33 @@ class HashIndexReader : public BlockBasedTable::IndexReaderCommon {
   std::unique_ptr<BlockPrefixIndex> prefix_index_;
 };
 
+// TODO(fyp)
+// May consider inherit from IndexReaderCommon, but input type Block seems
+// to require index block be list of key-value pairs
+class PLRIndexReader: public BlockBasedTable::IndexReader {
+  public:
+    static Status Create() {
+      assert(false);
+      std::string error_message =
+          "TODO(fyp): " + ToString(rep_->index_type);
+      return Status::InvalidArgument(error_message.c_str());
+    }
+    virtual ~IndexReader() = default;
+
+    InternalIteratorBase<IndexValue>* NewIterator(
+        const ReadOptions& read_options, bool disable_prefix_seek,
+        IndexBlockIter* iter, GetContext* get_context,
+        BlockCacheLookupContext* lookup_context) {
+      return nullptr;
+    }
+
+    size_t ApproximateMemoryUsage() const {
+      return -1;
+    }
+    
+    void CacheDependencies(bool /* pin */) {}
+}
+
 void BlockBasedTable::UpdateCacheHitMetrics(BlockType block_type,
                                             GetContext* get_context,
                                             size_t usage) const {
@@ -4087,6 +4114,10 @@ Status BlockBasedTable::CreateIndexReader(
                                        use_cache, prefetch, pin, lookup_context,
                                        index_reader);
       }
+    }
+    case BlockBasedTableOptions::kLearnedIndexWithPLR: {
+      // TODO(fyp)
+      return PLRIndexReader::Create();
     }
     default: {
       std::string error_message =

--- a/table/block_based/block_based_table_reader.cc
+++ b/table/block_based/block_based_table_reader.cc
@@ -801,10 +801,13 @@ class PLRIndexReader: public BlockBasedTable::IndexReader {
     // virtual ~IndexReader() = default;
 
     InternalIteratorBase<IndexValue>* NewIterator(
-        const ReadOptions& read_options, bool disable_prefix_seek,
-        IndexBlockIter* iter, GetContext* get_context,
-        BlockCacheLookupContext* lookup_context) {
-      read_options; disable_prefix_seek; iter; get_context; lookup_context;
+        const ReadOptions&, bool,
+        IndexBlockIter*, GetContext*,
+        BlockCacheLookupContext*) {
+    // InternalIteratorBase<IndexValue>* NewIterator(
+    //     const ReadOptions& read_options, bool disable_prefix_seek,
+    //     IndexBlockIter* iter, GetContext* get_context,
+    //     BlockCacheLookupContext* lookup_context) {
       return nullptr;
     }
 

--- a/table/block_based/index_builder.cc
+++ b/table/block_based/index_builder.cc
@@ -58,7 +58,7 @@ IndexBuilder* IndexBuilder::CreateIndexBuilder(
           table_opt.index_shortening, /* include_first_key */ true);
     } break;
     case BlockBasedTableOptions::kLearnedIndexWithPLR: {
-      // TODO: Extend IndexBuilder for our lovely learned index
+      // TODO(fyp): Extend IndexBuilder for our lovely learned index
       assert(!"To be developed in our FYP !!!!!");
     } break;
     default: {

--- a/table/block_based/index_builder.cc
+++ b/table/block_based/index_builder.cc
@@ -57,6 +57,10 @@ IndexBuilder* IndexBuilder::CreateIndexBuilder(
           table_opt.format_version, use_value_delta_encoding,
           table_opt.index_shortening, /* include_first_key */ true);
     } break;
+    case BlockBasedTableOptions::kLearnedIndexWithPLR: {
+      // TODO: Extend IndexBuilder for our lovely learned index
+      assert(!"To be developed in our FYP !!!!!");
+    } break;
     default: {
       assert(!"Do not recognize the index type ");
     } break;


### PR DESCRIPTION
- Extended `BlockBasedTableOptions::IndexType` enum for learned index with PLR.
- Added TODOs in other parts of code.
- Besides the TODOs we still need to check other classes including: `TableReader, BlockBasedTable, BlockBasedTableBuilder` etc.