### PR TITLE
Assert user_key input in PLRIndexBuilder and PLRBlockIter to have size <= 8

### DIFF
--- a/table/block_based/block_based_table_reader.cc
+++ b/table/block_based/block_based_table_reader.cc
@@ -366,7 +366,8 @@ Status BlockBasedTable::IndexReaderCommon::GetOrReadIndexBlock(
 // in the cache or not.
 //
 // Difference from IndexReaderCommon: Cache BlockContents instead of Block
-class BlockBasedTable::CustomIndexReaderCommon : public BlockBasedTable::IndexReader {
+class BlockBasedTable::CustomIndexReaderCommon : 
+                                          public BlockBasedTable::IndexReader {
  public:
   CustomIndexReaderCommon(const BlockBasedTable* t,
                     CachableEntry<BlockContents>&& index_block_contents)
@@ -380,7 +381,8 @@ class BlockBasedTable::CustomIndexReaderCommon : public BlockBasedTable::IndexRe
                                const ReadOptions& read_options, bool use_cache,
                                GetContext* get_context,
                                BlockCacheLookupContext* lookup_context,
-                               CachableEntry<BlockContents>* index_block_contents);
+                               CachableEntry<BlockContents>* 
+                                index_block_contents);
 
   const BlockBasedTable* table() const { return table_; }
 
@@ -417,10 +419,12 @@ class BlockBasedTable::CustomIndexReaderCommon : public BlockBasedTable::IndexRe
 
   Status GetOrReadIndexBlock(bool no_io, GetContext* get_context,
                              BlockCacheLookupContext* lookup_context,
-                             CachableEntry<BlockContents>* index_block_contents) const;
+                             CachableEntry<BlockContents>* index_block_contents) 
+                              const;
 
   size_t ApproximateIndexBlockMemoryUsage() const {
-    assert(!index_block_contents_.GetOwnValue() || index_block_contents_.GetValue() != nullptr);
+    assert(!index_block_contents_.GetOwnValue() || 
+            index_block_contents_.GetValue() != nullptr);
     return index_block_contents_.GetOwnValue()
                ? index_block_contents_.GetValue()->ApproximateMemoryUsage()
                : 0;
@@ -447,8 +451,9 @@ Status BlockBasedTable::CustomIndexReaderCommon::ReadIndexBlock(
 
   const Status s = table->RetrieveBlock(
       prefetch_buffer, read_options, rep->footer.index_handle(),
-      UncompressionDict::GetEmptyDict(), index_block_contents, BlockType::kIndex,
-      get_context, lookup_context, /* for_compaction */ false, use_cache);
+      UncompressionDict::GetEmptyDict(), index_block_contents, 
+      BlockType::kIndex, get_context, lookup_context, 
+      /* for_compaction */ false, use_cache);
 
   return s;
 }

--- a/table/block_based/block_based_table_reader.cc
+++ b/table/block_based/block_based_table_reader.cc
@@ -927,7 +927,8 @@ class PLRIndexReader: public BlockBasedTable::CustomIndexReaderCommon {
     if (prefetch || !use_cache) {
       const Status s =
           ReadIndexBlock(table, prefetch_buffer, ReadOptions(), use_cache,
-                         /*get_context=*/nullptr, lookup_context, &index_block_contents);
+                         /*get_context=*/nullptr, lookup_context, 
+                         &index_block_contents);
       if (!s.ok()) {
         return s;
       }
@@ -947,10 +948,14 @@ class PLRIndexReader: public BlockBasedTable::CustomIndexReaderCommon {
       const ReadOptions& read_options, bool /* disable_prefix_seek */,
       IndexBlockIter* iter, GetContext* get_context,
       BlockCacheLookupContext* lookup_context) override {
+    assert(!index_has_first_key());
+    assert(!index_key_includes_seq());
+
     const bool no_io = (read_options.read_tier == kBlockCacheTier);
     CachableEntry<BlockContents> index_block_contents;
     const Status s =
-        GetOrReadIndexBlock(no_io, get_context, lookup_context, &index_block_contents);
+        GetOrReadIndexBlock(no_io, get_context, lookup_context, 
+                            &index_block_contents);
     if (!s.ok()) {
       if (iter != nullptr) {
         iter->Invalidate(s);
@@ -966,10 +971,9 @@ class PLRIndexReader: public BlockBasedTable::CustomIndexReaderCommon {
     
     BlockContents* block_content = index_block_contents.GetValue();
 
-    // TODO(fyp): 99% will leak memory, need to fix, but lets see if logic is correct first
-    auto it = new PLRBlockIter(block_content, index_key_includes_seq(), 
-                                num_data_blocks_, 
-                                internal_comparator()->user_comparator());
+    // TODO(fyp): Unsure if there'll be memory leak or not
+    auto it = new PLRBlockIter(block_content, num_data_blocks_, 
+                               internal_comparator()->user_comparator());
     index_block_contents.TransferTo(it);
 
     return it;

--- a/table/block_based/index_builder.h
+++ b/table/block_based/index_builder.h
@@ -470,7 +470,6 @@ class PLRIndexBuilder: public IndexBuilder {
   //
   // Note: It seems that both input keys are internal keys, so we need to
   // ExtractUserKey() before storing.
-
   void AddIndexEntry(std::string* /*last_key_in_current_block*/,
                     const Slice* first_key_in_next_block,
                     const BlockHandle& block_handle) override {

--- a/table/block_based/index_builder.h
+++ b/table/block_based/index_builder.h
@@ -452,7 +452,8 @@ class PartitionedIndexBuilder : public IndexBuilder {
 // 3. Encode to a string using PLRDataRep.
 // The encoded string is stored as the final block contents in IndexBlocks.
 //
-// Note: For now, we don't care about include_first_key_.
+// Note: Currently, we use assert() to ensure index key has size <= 8.
+// Other possible solutions include truncate the index key to up to 8 chars.
 class PLRIndexBuilder: public IndexBuilder {
  public:
   PLRIndexBuilder() = delete;
@@ -472,6 +473,7 @@ class PLRIndexBuilder: public IndexBuilder {
     if (first_key_in_next_block != nullptr) {
       // current AddIndexEntry() call is not processing with:
       // current_block = last data block
+      assert(first_key_in_next_block->size() <= 8);
       helper_.AddPLRTrainingPoint(*first_key_in_next_block);
     }
     helper_.AddHandle(block_handle);
@@ -482,6 +484,7 @@ class PLRIndexBuilder: public IndexBuilder {
   void OnKeyAdded(const Slice& key) override {
     if (is_first_key_in_first_block_) {
       is_first_key_in_first_block_ = false;
+      assert(key.size() <= 8);
       helper_.AddPLRTrainingPoint(key);
     }
   }

--- a/table/block_based/index_builder.h
+++ b/table/block_based/index_builder.h
@@ -498,6 +498,16 @@ class PLRIndexBuilder: public IndexBuilder {
 
   size_t IndexSize() const override { return index_size_; }
 
+  // Returning false means the key in this plr index block is always a user key
+  // without a sequence number.
+  // This makes Property meta block writes 'true' for a field named
+  // 'index_key_is_user_key'.
+  // Then when the block-based table is read, the reader will set another field
+  // named 'index_key_includes_seq' as 'false'. This will affect the behavior
+  // of index iterator the reader uses/creates. 
+  // See the impact on iterator behavior from the class PLRBlockIter.
+  virtual bool seperator_is_key_plus_seq() { return false; }
+
  private:
   PLRBuilderHelper helper_;
   // If true, OnKeyAdded() will use helper_ to add an Point for PLR training

--- a/table/block_based/learned_index/plr/plr_block_iter.cc
+++ b/table/block_based/learned_index/plr/plr_block_iter.cc
@@ -223,7 +223,8 @@ void PLRBlockIter::SetCurrentIndexValue() {
 //
 // Note: This function assumes input data_block first/last keys are the keys of
 // the current data block (as pointed by current_).
-// Note: Only accepts user keys, but not internal keys.
+// Note: Only accepts internal keys. They will be converted to user keys 
+// internally.
 //
 // REQUIRES: Valid()
 // REQUIRES: binary seek mode
@@ -233,17 +234,21 @@ void PLRBlockIter::UpdateBinarySeekRange(const Slice& seek_key,
 	assert(Valid());
 	assert(seek_mode_ == SeekMode::kBinarySeek);
 
-	assert(user_comparator_->Compare(data_block_first_key, 
-																	data_block_last_key) <= 0);
+	Slice first_user_key = ExtractUserKey(data_block_first_key);
+	Slice last_user_key = ExtractUserKey(data_block_last_key);
+	Slice seek_user_key = ExtractUserKey(user_key);
+
+	assert(user_comparator_->Compare(first_user_key, 
+																	 last_user_key) <= 0);
 	
 	// Case 1: Seek key > All keys in current data block.
-	if (user_comparator_->Compare(data_block_last_key, seek_key) < 0) {
+	if (user_comparator_->Compare(last_user_key, seek_user_key) < 0) {
 		SetBeginBlockAsCurrent();
 		return;
 	}
 
 	// Case 2: Seek key < All keys in current data block.
-	if (user_comparator_->Compare(seek_key, data_block_first_key) < 0) {
+	if (user_comparator_->Compare(seek_user_key, first_user_key) < 0) {
 		SetEndBlockAsCurrent();
 		return;
 	}

--- a/table/block_based/learned_index/plr/plr_block_iter.cc
+++ b/table/block_based/learned_index/plr/plr_block_iter.cc
@@ -87,6 +87,8 @@ void PLRBlockIter::Seek(const Slice& target) {
 	Slice seek_key = target;
 	seek_key = ExtractUserKey(target);
 
+	assert(seek_key.size() <= 8);
+
 	status_ = helper_->PredictBlockRange(seek_key, begin_block_, end_block_);
 	if (!status_.ok()) {
 		return;

--- a/table/block_based/learned_index/plr/plr_block_iter.cc
+++ b/table/block_based/learned_index/plr/plr_block_iter.cc
@@ -75,6 +75,8 @@ void PLRBlockIter::SeekToLast() {
 // gamma error bound, helper_ uses a function pointer to convert the block 
 // number to an integer.
 //
+// Note: The input param. target is an internal key.
+//
 // REQUIRES: helper_ (and thus helper_->model_) is initialized.
 void PLRBlockIter::Seek(const Slice& target) {
 	TEST_SYNC_POINT("PLRBlockIter::Seek:0");
@@ -83,9 +85,7 @@ void PLRBlockIter::Seek(const Slice& target) {
 	seek_mode_ = SeekMode::kUnknown;
 	
 	Slice seek_key = target;
-	if (!key_includes_seq_) {
-		seek_key = ExtractUserKey(target);
-	}
+	seek_key = ExtractUserKey(target);
 
 	status_ = helper_->PredictBlockRange(seek_key, begin_block_, end_block_);
 	if (!status_.ok()) {

--- a/table/block_based/learned_index/plr/plr_block_iter.cc
+++ b/table/block_based/learned_index/plr/plr_block_iter.cc
@@ -236,7 +236,7 @@ void PLRBlockIter::UpdateBinarySeekRange(const Slice& seek_key,
 
 	Slice first_user_key = ExtractUserKey(data_block_first_key);
 	Slice last_user_key = ExtractUserKey(data_block_last_key);
-	Slice seek_user_key = ExtractUserKey(user_key);
+	Slice seek_user_key = ExtractUserKey(seek_key);
 
 	assert(user_comparator_->Compare(first_user_key, 
 																	 last_user_key) <= 0);

--- a/table/block_based/learned_index/plr/plr_block_iter.h
+++ b/table/block_based/learned_index/plr/plr_block_iter.h
@@ -71,15 +71,14 @@ class PLRBlockHelper {
 
 class PLRBlockIter : public InternalIteratorBase<IndexValue> {
  public:
-	PLRBlockIter(const BlockContents* contents, const bool key_includes_seq, 
-				const uint64_t num_data_blocks, const Comparator* user_comparator):
+	PLRBlockIter(const BlockContents* contents, const uint64_t num_data_blocks, 
+							const Comparator* user_comparator) :
 		InternalIteratorBase<IndexValue>(),
 		seek_mode_(SeekMode::kUnknown),
 		data_(contents->data),
 		current_(invalid_block_number_),
 		begin_block_(invalid_block_number_),
 		end_block_(invalid_block_number_),
-		key_includes_seq_(key_includes_seq),
 		value_(),
 		user_comparator_(user_comparator),
 		status_(),
@@ -176,7 +175,8 @@ class PLRBlockIter : public InternalIteratorBase<IndexValue> {
 	// key portion from it.
 	//
 	// Note: In Seek(target), target is always an internal key.
-	bool key_includes_seq_;
+	// bool key_includes_seq_ = false;
+	
 	static constexpr const char* key_extraction_not_supported_ = 
 																											"PLR_key()_not_supported";
 	IndexValue value_;

--- a/table/block_based/learned_index/plr/plr_block_iter.h
+++ b/table/block_based/learned_index/plr/plr_block_iter.h
@@ -205,7 +205,17 @@ class PLRBlockIter : public InternalIteratorBase<IndexValue> {
 	}
 
 	inline void SetEndBlockAsCurrent() {
-		end_block_ = current_ - 1;
+		if (current_ == 0) {
+			// This implies begin_block_ == 0, end_block_ == 0 or 1,
+			// but this function is called only after evaluating current_ and
+			// binary search results need to move end_block_ to the 'left'.
+			// In this case, after the subsequent Next(), iter shd becomes !Valid().
+			begin_block_ = 1;
+			end_block_ = 0;
+		}
+		else {
+			end_block_ = current_ - 1;
+		}
 	}
 
 	void SetCurrentIndexValue();

--- a/table/block_based/learned_index/plr/plr_block_iter.h
+++ b/table/block_based/learned_index/plr/plr_block_iter.h
@@ -69,6 +69,9 @@ class PLRBlockHelper {
 	};
 };
 
+// Note: Currently, we use assert() to ensure index keys Seek()ed through this
+// iterator has size <= 8, after ExtractUserKey().
+// Other possible solutions include truncating the length of seek key.
 class PLRBlockIter : public InternalIteratorBase<IndexValue> {
  public:
 	PLRBlockIter(const BlockContents* contents, const uint64_t num_data_blocks, 
@@ -176,7 +179,7 @@ class PLRBlockIter : public InternalIteratorBase<IndexValue> {
 	//
 	// Note: In Seek(target), target is always an internal key.
 	// bool key_includes_seq_ = false;
-	
+
 	static constexpr const char* key_extraction_not_supported_ = 
 																											"PLR_key()_not_supported";
 	IndexValue value_;


### PR DESCRIPTION
- Enforced `PLRIndexBuilder` to inform Properties meta block that it doesn't store sequence number in keys in index block, i.e. it stores user keys but not internal keys.
- Added `assert()` to make it impossible to use user_key with size > 8 for `PLRIndexBuilder` and `PLRBlockIter`.
- From my research, it seems there is no options for specifying the maximum user key size in normal usage.
  - Related (for value size): [https://github.com/facebook/rocksdb/issues/513](https://github.com/facebook/rocksdb/issues/513)
- But it seems there is such an option in benchmark test.