### PR TITLE
Fix (lots of) bugs to pass most stress test scenario for plr index

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "table/block_based/learned_index/plr/external/plr"]
 	path = table/block_based/learned_index/plr/external/plr
 	url = https://github.com/hkust-comp4981-di2-2023/plr-cpp.git
+	branch = fyp-specialized

--- a/db_stress_tool/batched_ops_stress.cc
+++ b/db_stress_tool/batched_ops_stress.cc
@@ -35,8 +35,6 @@ class BatchedOpsStressTest : public StressTest {
     Status s;
     auto cfh = column_families_[rand_column_families[0]];
     std::string key_str = Key(rand_keys[0]);
-    // Note(fyp): Truncate key_str to size <= 7
-    key_str = key_str.size() >= 8 ? key_str.substr(0, 7) : key_str;
     for (int i = 0; i < 10; i++) {
       keys[i] += key_str;
       values[i] += v.ToString();
@@ -125,8 +123,6 @@ class BatchedOpsStressTest : public StressTest {
     ReadOptions readoptionscopy = readoptions;
     readoptionscopy.snapshot = db_->GetSnapshot();
     std::string key_str = Key(rand_keys[0]);
-    // Note(fyp): Truncate key_str to size <= 7
-    key_str = key_str.size() >= 8 ? key_str.substr(0, 7) : key_str;
     Slice key = key_str;
     auto cfh = column_families_[rand_column_families[0]];
     std::string from_db;
@@ -195,11 +191,7 @@ class BatchedOpsStressTest : public StressTest {
       ColumnFamilyHandle* cfh = column_families_[rand_column_families[0]];
 
       for (size_t key = 0; key < num_prefixes; ++key) {
-        // key_str.emplace_back(keys[key] + Key(rand_keys[rand_key]));
-        // Note(fyp): Truncate tmp to size <= 8
-        std::string tmp = keys[key] + Key(rand_keys[rand_key]);
-        tmp = tmp.size() > 8 ? tmp.substr(0, 8) : tmp;
-        key_str.emplace_back(tmp);
+        key_str.emplace_back(keys[key] + Key(rand_keys[rand_key]));
         key_slices.emplace_back(key_str.back());
       }
       db_->MultiGet(readoptionscopy, cfh, num_prefixes, key_slices.data(),

--- a/db_stress_tool/db_stress_common.h
+++ b/db_stress_tool/db_stress_common.h
@@ -394,7 +394,7 @@ extern inline std::string GetStringFromIntForFYP(int32_t val) {
 }
 
 // Note(fyp): Override by FYP stress testing modifications.
-// Note(fyP): max_key can be represented by 32-bits.
+// Note(fyp): max_key can be represented by 32-bits.
 // Generate a variable length key string from the given int64 val. The
 // order of the keys is preserved. The key could be anywhere from 8 to
 // max_key_len * 8 bytes.
@@ -406,9 +406,9 @@ extern inline std::string GetStringFromIntForFYP(int32_t val) {
 // {(x-1),0}..{(x-1),(y-1)},{(x-1),(y-1),0}..{(x-1),(y-1),(z-1)} and so on.
 // Additionally, a trailer of 0-7 bytes could be appended.
 extern inline std::string Key(int64_t val) {
-  std::string key;
-  key.append(GetStringFromIntForFYP((int32_t) val));
+  return GetStringFromIntForFYP((int32_t) val);
   /*
+  std::string key;
   uint64_t window = key_gen_ctx.window;
   size_t levels = key_gen_ctx.weights.size();
   std::string key;
@@ -443,9 +443,9 @@ extern inline std::string Key(int64_t val) {
     fprintf(stdout, "Key() [%s] has size < 8, now truncated\n", key.c_str());
     key = key.substr(0, 8);
   }
-  */
 
   return key;
+  */
 }
 
 // Given a string key, map it to an index into the expected values buffer

--- a/db_stress_tool/db_stress_common.h
+++ b/db_stress_tool/db_stress_common.h
@@ -379,6 +379,22 @@ struct KeyGenContext {
 };
 extern KeyGenContext key_gen_ctx;
 
+// Note(fyp): For 32-bit int only.
+// convert long to a big-endian slice key
+extern inline std::string GetStringFromIntForFYP(int32_t val) {
+  std::string little_endian_key;
+  std::string big_endian_key;
+  PutFixed32(&little_endian_key, val);
+  assert(little_endian_key.size() == sizeof(val));
+  big_endian_key.resize(sizeof(val));
+  for (size_t i = 0; i < sizeof(val); ++i) {
+    big_endian_key[i] = little_endian_key[sizeof(val) - 1 - i];
+  }
+  return big_endian_key;
+}
+
+// Note(fyp): Override by FYP stress testing modifications.
+// Note(fyP): max_key can be represented by 32-bits.
 // Generate a variable length key string from the given int64 val. The
 // order of the keys is preserved. The key could be anywhere from 8 to
 // max_key_len * 8 bytes.
@@ -390,6 +406,9 @@ extern KeyGenContext key_gen_ctx;
 // {(x-1),0}..{(x-1),(y-1)},{(x-1),(y-1),0}..{(x-1),(y-1),(z-1)} and so on.
 // Additionally, a trailer of 0-7 bytes could be appended.
 extern inline std::string Key(int64_t val) {
+  std::string key;
+  key.append(GetStringFromIntForFYP((int32_t) val));
+  /*
   uint64_t window = key_gen_ctx.window;
   size_t levels = key_gen_ctx.weights.size();
   std::string key;
@@ -400,7 +419,7 @@ extern inline std::string Key(int64_t val) {
     uint64_t mult = static_cast<uint64_t>(val) / window;
     uint64_t pfx = mult * weight + (offset >= weight ? weight - 1 : offset);
     key.append(GetStringFromInt(pfx));
-    /* Note(fyp): Disabled to ensure key length <= 8
+    // Note(fyp): Disabled to ensure key length <= 8
     if (offset < weight) {
       // Use the bottom 3 bits of offset as the number of trailing 'x's in the
       // key. If the next key is going to be of the next level, then skip the
@@ -412,7 +431,7 @@ extern inline std::string Key(int64_t val) {
       }
       break;
     }
-    */
+    
     val = offset - weight;
     window -= weight;
   }
@@ -424,6 +443,7 @@ extern inline std::string Key(int64_t val) {
     fprintf(stdout, "Key() [%s] has size < 8, now truncated\n", key.c_str());
     key = key.substr(0, 8);
   }
+  */
 
   return key;
 }

--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -1123,6 +1123,12 @@ void StressTest::VerifyIterator(ThreadState* thread,
         } else {
           fprintf(stderr, "iterator is not valid\n");
         }
+        // TODO(fyp): Remove this
+        PLRBlockIter* plr_block_iter = dynamic_cast<PLRBlockIter*>(iter);
+        if (plr_block_iter != nullptr) {
+          fprintf(stderr, "plr block iter has op_logs:{%s}\n", 
+                  plr_block_iter->GetOpLogs());
+        }
         *diverged = true;
       }
     }

--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -1127,7 +1127,7 @@ void StressTest::VerifyIterator(ThreadState* thread,
         PLRBlockIter* plr_block_iter = dynamic_cast<PLRBlockIter*>(iter);
         if (plr_block_iter != nullptr) {
           fprintf(stderr, "plr block iter has op_logs:{%s}\n", 
-                  plr_block_iter->GetOpLogs());
+                  plr_block_iter->GetOpLogs().c_str());
         }
         *diverged = true;
       }

--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -938,6 +938,7 @@ Status StressTest::TestIterate(ThreadState* thread,
                    last_op, key, op_logs, &diverged);
     
     // TODO(fyp): Remove this
+    /*
     if (diverged) {
       fprintf(stderr, 
               "Diverged after checkpoint 1: {iter->key()=%s} "
@@ -946,6 +947,7 @@ Status StressTest::TestIterate(ThreadState* thread,
               cmp_iter->Valid() ? cmp_iter->key().ToString(true).c_str() : "Invalid()",
               op_logs.c_str());
     }
+    */
 
     bool no_reverse =
         (FLAGS_memtablerep == "prefix_hash" && !expect_total_order);
@@ -970,6 +972,7 @@ Status StressTest::TestIterate(ThreadState* thread,
                      cmp_iter.get(), last_op, key, op_logs, &diverged);
     }
 
+    /*
     if (diverged) {
       fprintf(stderr, 
               "Diverged after checkpoint 2: {iter->key()=%s} "
@@ -978,6 +981,7 @@ Status StressTest::TestIterate(ThreadState* thread,
               cmp_iter->Valid() ? cmp_iter->key().ToString(true).c_str() : "Invalid()",
               op_logs.c_str());
     }
+    */
 
     if (s.ok()) {
       thread->stats.AddIterations(1);

--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -936,6 +936,11 @@ Status StressTest::TestIterate(ThreadState* thread,
     }
     VerifyIterator(thread, cmp_cfh, readoptionscopy, iter.get(), cmp_iter.get(),
                    last_op, key, op_logs, &diverged);
+    
+    // TODO(fyp): Remove this
+    if (diverged) {
+      fprintf(stderr, "Diverged after checkpoint 1: {%s}\n", op_logs.c_str());
+    }
 
     bool no_reverse =
         (FLAGS_memtablerep == "prefix_hash" && !expect_total_order);
@@ -958,6 +963,10 @@ Status StressTest::TestIterate(ThreadState* thread,
       last_op = kLastOpNextOrPrev;
       VerifyIterator(thread, cmp_cfh, readoptionscopy, iter.get(),
                      cmp_iter.get(), last_op, key, op_logs, &diverged);
+    }
+
+    if (diverged) {
+      fprintf(stderr, "Diverged after checkpoint 2: {%s}\n", op_logs.c_str());
     }
 
     if (s.ok()) {
@@ -1122,12 +1131,6 @@ void StressTest::VerifyIterator(ThreadState* thread,
                   iter->key().ToString(true).c_str());
         } else {
           fprintf(stderr, "iterator is not valid\n");
-        }
-        // TODO(fyp): Remove this
-        PLRBlockIter* plr_block_iter = dynamic_cast<PLRBlockIter*>(iter);
-        if (plr_block_iter != nullptr) {
-          fprintf(stderr, "plr block iter has op_logs:{%s}\n", 
-                  plr_block_iter->GetOpLogs().c_str());
         }
         *diverged = true;
       }

--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -939,7 +939,12 @@ Status StressTest::TestIterate(ThreadState* thread,
     
     // TODO(fyp): Remove this
     if (diverged) {
-      fprintf(stderr, "Diverged after checkpoint 1: {%s}\n", op_logs.c_str());
+      fprintf(stderr, 
+              "Diverged after checkpoint 1: {iter->key()=%s} "
+              "{cmp_iter->key=()%s} {%s}\n",
+              iter->Valid() ? iter->key().ToString(true).c_str() : "Invalid()",
+              cmp_iter->Valid() ? cmp_iter->key().ToString(true).c_str() : "Invalid()",
+              op_logs.c_str());
     }
 
     bool no_reverse =
@@ -966,7 +971,12 @@ Status StressTest::TestIterate(ThreadState* thread,
     }
 
     if (diverged) {
-      fprintf(stderr, "Diverged after checkpoint 2: {%s}\n", op_logs.c_str());
+      fprintf(stderr, 
+              "Diverged after checkpoint 2: {iter->key()=%s} "
+              "{cmp_iter->key=()%s} {%s}\n",
+              iter->Valid() ? iter->key().ToString(true).c_str() : "Invalid()",
+              cmp_iter->Valid() ? cmp_iter->key().ToString(true).c_str() : "Invalid()",
+              op_logs.c_str());
     }
 
     if (s.ok()) {

--- a/db_stress_tool/db_stress_test_base.h
+++ b/db_stress_tool/db_stress_test_base.h
@@ -11,6 +11,8 @@
 #pragma once
 #include "db_stress_tool/db_stress_common.h"
 #include "db_stress_tool/db_stress_shared_state.h"
+// TODO(fyp): Remove this with VerifyIterator() additional logic
+#include "table/block_based/learned_index/plr/plr_block_iter.h"
 
 namespace ROCKSDB_NAMESPACE {
 class Transaction;

--- a/db_stress_tool/db_stress_test_base.h
+++ b/db_stress_tool/db_stress_test_base.h
@@ -11,8 +11,6 @@
 #pragma once
 #include "db_stress_tool/db_stress_common.h"
 #include "db_stress_tool/db_stress_shared_state.h"
-// TODO(fyp): Remove this with VerifyIterator() additional logic
-#include "table/block_based/learned_index/plr/plr_block_iter.h"
 
 namespace ROCKSDB_NAMESPACE {
 class Transaction;

--- a/db_stress_tool/no_batched_ops_stress.cc
+++ b/db_stress_tool/no_batched_ops_stress.cc
@@ -33,7 +33,9 @@ class NonBatchedOpsStressTest : public StressTest {
       if (thread->shared->HasVerificationFailedYet()) {
         break;
       }
-      if (!thread->rand.OneIn(2)) {
+      // Note(fyp): Disable iterator for VerifyDb() for now
+      if (!thread->rand.OneIn(1)) {
+      // if (!thread->rand.OneIn(2)) {
         // Use iterator to verify this range
         Slice prefix;
         std::string seek_key = Key(start);

--- a/db_stress_tool/no_batched_ops_stress.cc
+++ b/db_stress_tool/no_batched_ops_stress.cc
@@ -34,8 +34,8 @@ class NonBatchedOpsStressTest : public StressTest {
         break;
       }
       // Note(fyp): Disable iterator for VerifyDb() for now
-      if (!thread->rand.OneIn(1)) {
-      // if (!thread->rand.OneIn(2)) {
+      // if (!thread->rand.OneIn(1)) {
+      if (!thread->rand.OneIn(2)) {
         // Use iterator to verify this range
         Slice prefix;
         std::string seek_key = Key(start);

--- a/table/block_based/block_based_table_reader.cc
+++ b/table/block_based/block_based_table_reader.cc
@@ -3103,7 +3103,7 @@ void BlockBasedTableIterator<TBlockIter, TValue>::SeekImpl(
         if (plr_index_iter->Valid()) {
           block_iter_.SeekToFirst();
         } else {
-          plr_index_iter.SetStatus(Status::NotFound());
+          plr_index_iter->SetStatus(Status::NotFound());
         }
       }
     } else {

--- a/table/block_based/block_based_table_reader.cc
+++ b/table/block_based/block_based_table_reader.cc
@@ -3091,7 +3091,7 @@ void BlockBasedTableIterator<TBlockIter, TValue>::SeekImpl(
           }
 
           // Internal key comparison: target > data_block_last_key
-          plr_index_iter.Next();
+          plr_index_ite->Next();
           InitDataBlock();
           prev_block_offset_ = index_iter_->value().handle.offset();
         }
@@ -3227,13 +3227,13 @@ void BlockBasedTableIterator<TBlockIter, TValue>::SeekForPrev(
       block_iter_.SeekToLast();
       Slice data_block_last_key = block_iter_.key();
 
-      if (icomp_.Compare(data_block_first_key, *target) <= 0 &&
-          icomp_.Compare(*target, data_block_last_key) <= 0) {
+      if (icomp_.Compare(data_block_first_key, target) <= 0 &&
+          icomp_.Compare(target, data_block_last_key) <= 0) {
         break;
       }
 
       // Either target < data_block_first_key or data_block_last_key < target
-      if (icomp_.Compare(*target, data_block_first_key) < 0) {
+      if (icomp_.Compare(target, data_block_first_key) < 0) {
         // target < data_block_first_key
         plr_index_iter->Prev();
         InitDataBlock();
@@ -3253,7 +3253,7 @@ void BlockBasedTableIterator<TBlockIter, TValue>::SeekForPrev(
       // break. Otherwise, target >= data_block_first_key, we need to continue 
       // Next().
       break_at_prev = true;
-      plr_index_iter.Next();
+      plr_index_iter->Next();
       InitDataBlock();
       prev_block_offset_ = index_iter_->value().handle.offset();
     }

--- a/table/block_based/block_based_table_reader.cc
+++ b/table/block_based/block_based_table_reader.cc
@@ -5041,6 +5041,7 @@ void BlockBasedTable::SetUpPLRBlockIterAfterInitialSeek(const Slice& key,
     assert(plr_block_iter->Valid());
 
     // Move current_ until key.seqno >= some seqno in the data block.
+    /*
     while (plr_block_iter->Valid() && 
             rep_->internal_comparator.Compare(key, last_key) > 0) {
       DataBlockIter biter;
@@ -5058,6 +5059,45 @@ void BlockBasedTable::SetUpPLRBlockIterAfterInitialSeek(const Slice& key,
     assert(!plr_block_iter->Valid() ||
             (rep_->internal_comparator.Compare(first_key, key) <= 0 &&
              rep_->internal_comparator.Compare(key, last_key) <= 0));
+    */
+    bool break_at_prev = false;
+    while (plr_block_iter->Valid() && 
+            !(rep_->internal_comparator.Compare(first_key, key) <= 0 &&
+              rep_->internal_comparator.Compare(key, last_key) <= 0)) {
+      DataBlockIter biter;
+      if (rep_->internal_comparator.Compare(key, last_key) > 0) {
+        break_at_prev = true;
+        plr_block_iter->Next();
+        if (plr_block_iter->Valid()) {
+          IndexValue v = plr_block_iter->value();
+          NewDataBlockIterator<DataBlockIter>(
+              read_options, v.handle, &biter, BlockType::kData, get_context,
+              &lookup_context, Status(), nullptr);
+          biter.SeekToLast();
+          first_key = biter.key(); // for debug purpose
+          last_key = biter.key();
+        }
+      }
+      else if (rep_->internal_comparator.Compare(first_key, key) > 0) {
+        plr_block_iter->Prev();
+        if (plr_block_iter->Valid()) {
+          IndexValue v = plr_block_iter->value();
+          NewDataBlockIterator<DataBlockIter>(
+              read_options, v.handle, &biter, BlockType::kData, get_context,
+              &lookup_context, Status(), nullptr);
+          biter.SeekToLast();
+          first_key = biter.key(); // for debug purpose
+          last_key = biter.key();
+        } else {
+          plr_block_iter->SeekToFirst();
+          break;
+        }
+
+        if (break_at_prev) {
+          break;
+        }
+      }
+    }
     return;
   }
   assert(!"Input index iterator iiter must be PLRBlockIter");

--- a/table/block_based/block_based_table_reader.cc
+++ b/table/block_based/block_based_table_reader.cc
@@ -3727,7 +3727,7 @@ Status BlockBasedTable::Get(const ReadOptions& read_options, const Slice& key,
           plr_iter_first_seek) {
         SetUpPLRBlockIterAfterInitialSeek(key, iiter, 
             read_options, lookup_context, get_context);
-        if (!plr_iter_first_seek->Valid()) {
+        if (!iiter->Valid()) {
           // TODO(fyp): Test if this logic is correct. If not, change SetUp..()
           // so that the iter remains Valid().
           break;
@@ -4996,9 +4996,9 @@ void BlockBasedTable::SetUpPLRBlockIterAfterInitialSeek(const Slice& key,
     // We call Next() and UpdateBinarySeekRange() until the correct block 
     // is found.
     PLRBlockIter* plr_block_iter = reinterpret_cast<PLRBlockIter*>(iiter);
+    DataBlockIter biter;
     while (plr_block_iter->Valid()) {
       IndexValue v = plr_block_iter->value();
-      DataBlockIter biter;
       NewDataBlockIterator<DataBlockIter>(
           read_options, v.handle, &biter, BlockType::kData, get_context,
           &lookup_context, Status(), nullptr);
@@ -5024,7 +5024,6 @@ void BlockBasedTable::SetUpPLRBlockIterAfterInitialSeek(const Slice& key,
       plr_block_iter->Next();
       if (plr_block_iter->Valid()) {
         IndexValue v = plr_block_iter->value();
-        DataBlockIter biter;
         NewDataBlockIterator<DataBlockIter>(
             read_options, v.handle, &biter, BlockType::kData, get_context,
             &lookup_context, Status(), nullptr);

--- a/table/block_based/block_based_table_reader.cc
+++ b/table/block_based/block_based_table_reader.cc
@@ -4318,11 +4318,11 @@ void BlockBasedTable::MultiGet(const ReadOptions& read_options,
         }
       } while (iiter->Valid());
 
-      if (!first_block) {
-        // Note(fyp): If we reused or initialized next_biter in this iteration,
-        // we will try to reuse next_biter in the next iterations if needed.
-        is_last_plr_biter_set = true;
-      }
+      // if (!first_block) {
+      //   // Note(fyp): If we reused or initialized next_biter in this iteration,
+      //   // we will try to reuse next_biter in the next iterations if needed.
+      //   is_last_plr_biter_set = true;
+      // }
 
       if (matched && filter != nullptr && !filter->IsBlockBased()) {
         RecordTick(rep_->ioptions.statistics, BLOOM_FILTER_FULL_TRUE_POSITIVE);

--- a/table/block_based/block_based_table_reader.cc
+++ b/table/block_based/block_based_table_reader.cc
@@ -3091,7 +3091,7 @@ void BlockBasedTableIterator<TBlockIter, TValue>::SeekImpl(
           }
 
           // Internal key comparison: target > data_block_last_key
-          plr_index_ite->Next();
+          plr_index_iter->Next();
           InitDataBlock();
           prev_block_offset_ = index_iter_->value().handle.offset();
         }

--- a/table/block_based/block_based_table_reader.cc
+++ b/table/block_based/block_based_table_reader.cc
@@ -5051,9 +5051,13 @@ void BlockBasedTable::SetUpPLRBlockIterAfterInitialSeek(const Slice& key,
             read_options, v.handle, &biter, BlockType::kData, get_context,
             &lookup_context, Status(), nullptr);
         biter.SeekToLast();
+        first_key = biter.key(); // for debug purpose
         last_key = biter.key();
       }
     }
+    assert(!plr_block_iter->Valid() ||
+            (rep_->internal_comparator.Compare(first_key, key) <= 0 &&
+             rep_->internal_comparator.Compare(key, last_key) <= 0));
     return;
   }
   assert(!"Input index iterator iiter must be PLRBlockIter");

--- a/table/block_based/block_based_table_reader.cc
+++ b/table/block_based/block_based_table_reader.cc
@@ -3327,12 +3327,12 @@ void BlockBasedTableIterator<TBlockIter, TValue>::SeekForPrev(
       block_iter_.SeekToLast();
       Slice data_block_last_key = block_iter_.key();
 
-      if (icomp_.Compare(data_block_first_key, *target) <= 0 &&
-          icomp_.Compare(*target, data_block_last_key) <= 0) {
+      if (icomp_.Compare(data_block_first_key, target) <= 0 &&
+          icomp_.Compare(target, data_block_last_key) <= 0) {
         break;
       }
 
-      if (icomp_.Compare(*target, data_block_last_key) > 0) {
+      if (icomp_.Compare(target, data_block_last_key) > 0) {
         plr_index_iter->Next();
         continue;
       }
@@ -3357,12 +3357,12 @@ void BlockBasedTableIterator<TBlockIter, TValue>::SeekForPrev(
       block_iter_.SeekToLast();
       Slice data_block_last_key = block_iter_.key();
 
-      if (icomp_.Compare(data_block_first_key, *target) <= 0 &&
-          icomp_.Compare(*target, data_block_last_key) <= 0) {
+      if (icomp_.Compare(data_block_first_key, target) <= 0 &&
+          icomp_.Compare(target, data_block_last_key) <= 0) {
         break;
       }
 
-      if (icomp_.Compare(data_block_first_key, *target) > 0) {
+      if (icomp_.Compare(data_block_first_key, target) > 0) {
         plr_index_iter->Prev();
         continue;
       }

--- a/table/block_based/block_based_table_reader.cc
+++ b/table/block_based/block_based_table_reader.cc
@@ -5017,7 +5017,8 @@ void BlockBasedTable::SetUpPLRBlockIterAfterInitialSeek(const Slice& key,
     PLRBlockIter* plr_block_iter = reinterpret_cast<PLRBlockIter*>(iiter);
     Slice first_key, last_key;
 
-    plr_block_iter->SeekToFirst();
+    plr_block_iter->SeekBeginBlock();
+    plr_block_iter->SwitchToLinearSeekMode();
     while (plr_block_iter->Valid()) {
       DataBlockIter biter;
       IndexValue v = plr_block_iter->value();

--- a/table/block_based/block_based_table_reader.cc
+++ b/table/block_based/block_based_table_reader.cc
@@ -3092,10 +3092,17 @@ void BlockBasedTableIterator<TBlockIter, TValue>::SeekImpl(
 
           // Internal key comparison: target > data_block_last_key
           plr_index_iter->Next();
+          if (!plr_index_iter->Valid()) {
+            break;
+          }
+
           InitDataBlock();
           prev_block_offset_ = index_iter_->value().handle.offset();
         }
-        block_iter_.SeekToFirst();
+
+        if (plr_index_iter->Valid()) {
+          block_iter_.SeekToFirst();
+        }
       }
     } else {
       index_iter_->SeekToFirst();
@@ -3236,6 +3243,10 @@ void BlockBasedTableIterator<TBlockIter, TValue>::SeekForPrev(
       if (icomp_.Compare(target, data_block_first_key) < 0) {
         // target < data_block_first_key
         plr_index_iter->Prev();
+        if (!plr_index_iter->Valid()) {
+          break;
+        }
+
         InitDataBlock();
         prev_block_offset_ = index_iter_->value().handle.offset();
         if (break_at_prev) {
@@ -3254,6 +3265,10 @@ void BlockBasedTableIterator<TBlockIter, TValue>::SeekForPrev(
       // Next().
       break_at_prev = true;
       plr_index_iter->Next();
+      if (!plr_index_iter->Valid()) {
+        break;
+      }
+      
       InitDataBlock();
       prev_block_offset_ = index_iter_->value().handle.offset();
     }

--- a/table/block_based/block_based_table_reader.cc
+++ b/table/block_based/block_based_table_reader.cc
@@ -3102,6 +3102,8 @@ void BlockBasedTableIterator<TBlockIter, TValue>::SeekImpl(
 
         if (plr_index_iter->Valid()) {
           block_iter_.SeekToFirst();
+        } else {
+          plr_index_iter.SetStatus(Status::NotFound());
         }
       }
     } else {
@@ -3244,6 +3246,7 @@ void BlockBasedTableIterator<TBlockIter, TValue>::SeekForPrev(
         // target < data_block_first_key
         plr_index_iter->Prev();
         if (!plr_index_iter->Valid()) {
+          plr_index_iter->SetStatus(Status::NotFound());
           break;
         }
 
@@ -3266,9 +3269,10 @@ void BlockBasedTableIterator<TBlockIter, TValue>::SeekForPrev(
       break_at_prev = true;
       plr_index_iter->Next();
       if (!plr_index_iter->Valid()) {
+        plr_index_iter->SetStatus(Status::NotFound());
         break;
       }
-      
+
       InitDataBlock();
       prev_block_offset_ = index_iter_->value().handle.offset();
     }

--- a/table/block_based/block_test.cc
+++ b/table/block_based/block_test.cc
@@ -949,7 +949,6 @@ TEST_P(PLRIndexBlockTest, PLRIndexValueEncodingTest) {
     // search in block for this key
     iter->Seek(query_key);
     IndexValue v;
-    const Comparator* cmp = options.comparator;
     while (iter->Valid()) {
       v = iter->value();
       int seek_result_index = reverse_index[v.handle.offset()];
@@ -965,14 +964,14 @@ TEST_P(PLRIndexBlockTest, PLRIndexValueEncodingTest) {
         iter->SwitchToLinearSeekMode();
         // Special handling for cases where multiple internal keys with the
         // same user key but different seq_no exist.
-        while (icomp.Compare(query_key, seek_result_last_key) < 0) {
+        while (icomp.Compare(query_key, seek_result_first_key) > 0) {
           iter->Next();
           if (!iter->Valid()) {
             break;
           }
           v = iter->value();
           seek_result_index = reverse_index[v.handle.offset()];
-          seek_result_last_key= Slice(last_keys[seek_result_index]);
+          seek_result_first_key = Slice(first_keys[seek_result_index]);
         }
         break;
       }

--- a/table/block_based/block_test.cc
+++ b/table/block_based/block_test.cc
@@ -699,10 +699,14 @@ TEST_P(PLRIndexBlockTest, PLRIndexValueEncodingTest) {
   Slice key(first_keys[0]);
   builder.OnKeyAdded(key);
   for (int i = 1; i < num_records; ++i) {
-    key = Slice(first_keys[i]);
-    builder.AddIndexEntry(nullptr, &key, block_handles[i-1]);
-    builder.OnKeyAdded(key);
+    Slice first_key = Slice(first_keys[i]);
+    Slice last_key = Slice(last_keys[i-1]);
+    builder.OnKeyAdded(last_key);
+    builder.AddIndexEntry(nullptr, &first_key, block_handles[i-1]);
+    builder.OnKeyAdded(first_key);
   }
+  key = Slice(last_keys[num_records-1]);
+  builder.OnKeyAdded(key);
   builder.AddIndexEntry(nullptr, nullptr, block_handles[num_records-1]);
 
   // read serialized contents of the block

--- a/table/block_based/block_test.cc
+++ b/table/block_based/block_test.cc
@@ -635,8 +635,8 @@ class PLRIndexBlockTest
 std::string MakeKeyLookLikeInternalKey(const std::string& key) {
   return key + "12345678";
 }
-string uint2str(uint64_t x) {
-    string s = "";
+std::string uint2str(uint64_t x) {
+    std::string s = "";
     for (int i = 7; i >= 0; --i) {
         uint64_t mask = 0xFFULL << (8 * i);
         unsigned char t = (mask & x) >> (8 * i);

--- a/table/block_based/block_test.cc
+++ b/table/block_based/block_test.cc
@@ -960,7 +960,6 @@ TEST_P(PLRIndexBlockTest, PLRIndexValueEncodingTest) {
   // should point to the closest data block with first_key > out_of_block_key,
   // if such block exists (if not exists, becomes !Valid()).
   // printf("Test 4\n");
-  /*
   iter = new PLRBlockIter(&block_contents, num_records, &icomp);
   for (int i = 0; i < num_records * 2; i++) {
     // find a random key in the lookaside array
@@ -1008,7 +1007,6 @@ TEST_P(PLRIndexBlockTest, PLRIndexValueEncodingTest) {
   }
   delete iter;
   iter = nullptr;
-  */
 
 }
 

--- a/table/block_based/block_test.cc
+++ b/table/block_based/block_test.cc
@@ -748,9 +748,12 @@ TEST_P(PLRIndexBlockTest, PLRIndexValueEncodingTest) {
     iter->Seek(query_key);
     IndexValue v;
     while (iter->Valid()) {
-      // printf("%s\n", iter->GetStateMessage().c_str());
+      printf("%s\n", iter->GetStateMessage().c_str());
       v = iter->value();
       int seek_result_index = reverse_index[v.handle.offset()];
+      printf("Seek Key: %s\t DataBlk First Key: %s\t DataBlk Last Key: %s\n\n",
+        query_key.ToString().c_str(), first_keys[seek_result_index].c_str(),
+        last_keys[seek_result_index].c_str());
       
       // check if the extracted block_handle matches the one in block_handles
       if (seek_result_index == expected_index) {

--- a/table/block_based/block_test.cc
+++ b/table/block_based/block_test.cc
@@ -636,7 +636,7 @@ class PLRIndexBlockTest
 std::string MakeKeyLookLikeInternalKey(const std::string& key) {
   static uint64_t seq_no = 1;
   char buf[8];
-  EncodeFixed64(buf, (seq_no++) << 8 + 1);
+  EncodeFixed64(buf, ((seq_no++) << 8) + 1);
   std::string seq_no_str(buf, 8);
 
   return key + seq_no_str;

--- a/table/block_based/block_test.cc
+++ b/table/block_based/block_test.cc
@@ -664,10 +664,10 @@ void GenerateRandomPLRIndexEntries(std::vector<BlockHandle> *block_handles,
     keys.insert(test::RandomKey(&rnd, 8));
   }
 
-  keys.insert(uint2str(18446744073709551612));
-  keys.insert(uint2str(18446744073709551613));
-  keys.insert(uint2str(18446744073709551614));
-  keys.insert(uint2str(18446744073709551615));
+  keys.insert(uint2str(18446744073709551612ULL));
+  keys.insert(uint2str(18446744073709551613ULL));
+  keys.insert(uint2str(18446744073709551614ULL));
+  keys.insert(uint2str(18446744073709551615ULL));
 
   uint64_t offset = 0;
   int idx = 0;

--- a/table/block_based/block_test.cc
+++ b/table/block_based/block_test.cc
@@ -700,11 +700,15 @@ TEST_P(PLRIndexBlockTest, PLRIndexValueEncodingTest) {
   builder.OnKeyAdded(key);
   for (int i = 1; i < num_records; ++i) {
     Slice first_key = Slice(first_keys[i]);
+    Slice middle_key = Slice(in_block_keys[i-1]);
     Slice last_key = Slice(last_keys[i-1]);
+    builder.OnKeyAdded(middle_key);
     builder.OnKeyAdded(last_key);
     builder.AddIndexEntry(nullptr, &first_key, block_handles[i-1]);
     builder.OnKeyAdded(first_key);
   }
+  key = Slice(in_block_keys[num_records-1]);
+  builder.OnKeyAdded(key);
   key = Slice(last_keys[num_records-1]);
   builder.OnKeyAdded(key);
   builder.AddIndexEntry(nullptr, nullptr, block_handles[num_records-1]);

--- a/table/block_based/block_test.cc
+++ b/table/block_based/block_test.cc
@@ -879,29 +879,25 @@ TEST_P(PLRIndexBlockTest, PLRIndexValueEncodingTest) {
         // last_keys[seek_result_index].c_str());
       
       // check if the extracted block_handle matches the one in block_handles
-      if (seek_result_index == expected_index) {
-        break;
-      } else {
-        Slice seek_result_first_key(first_keys[seek_result_index]);
-        Slice seek_result_last_key(last_keys[seek_result_index]);
-        iter->UpdateBinarySeekRange(query_key, seek_result_first_key, 
-                                    seek_result_last_key);
-        if (iter->IsLastBinarySeek()) {
-          iter->SwitchToLinearSeekMode();
-          // Special handling for cases where multiple internal keys with the
-          // same user key but different seq_no exist.
-          while (iter->Valid() && icomp.Compare(query_key, seek_result_last_key) > 0) {
-            iter->Next();
-            if (iter->Valid()) {
-              v = iter->value();
-              seek_result_index = reverse_index[v.handle.offset()];
-              seek_result_last_key = Slice(last_keys[seek_result_index]);
-            }
+      Slice seek_result_first_key(first_keys[seek_result_index]);
+      Slice seek_result_last_key(last_keys[seek_result_index]);
+      iter->UpdateBinarySeekRange(query_key, seek_result_first_key, 
+                                  seek_result_last_key);
+      if (iter->IsLastBinarySeek()) {
+        iter->SwitchToLinearSeekMode();
+        // Special handling for cases where multiple internal keys with the
+        // same user key but different seq_no exist.
+        while (iter->Valid() && icomp.Compare(query_key, seek_result_last_key) > 0) {
+          iter->Next();
+          if (iter->Valid()) {
+            v = iter->value();
+            seek_result_index = reverse_index[v.handle.offset()];
+            seek_result_last_key = Slice(last_keys[seek_result_index]);
           }
-          break;
         }
-        iter->Next();
+        break;
       }
+      iter->Next();
     }
     
     // EXPECT_EQ(separators[expected_index], iter->key().ToString());
@@ -930,29 +926,25 @@ TEST_P(PLRIndexBlockTest, PLRIndexValueEncodingTest) {
       int seek_result_index = reverse_index[v.handle.offset()];
       
       // check if the extracted block_handle matches the one in block_handles
-      if (seek_result_index == expected_index) {
-        break;
-      } else {
-        Slice seek_result_first_key(first_keys[seek_result_index]);
-        Slice seek_result_last_key(last_keys[seek_result_index]);
-        iter->UpdateBinarySeekRange(query_key, seek_result_first_key, 
-                                    seek_result_last_key);
-        if (iter->IsLastBinarySeek()) {
-          iter->SwitchToLinearSeekMode();
-          // Special handling for cases where multiple internal keys with the
-          // same user key but different seq_no exist.
-          while (iter->Valid() && icomp.Compare(query_key, seek_result_last_key) > 0) {
-            iter->Next();
-            if (iter->Valid()) {
-              v = iter->value();
-              seek_result_index = reverse_index[v.handle.offset()];
-              seek_result_last_key = Slice(last_keys[seek_result_index]);
-            }
+      Slice seek_result_first_key(first_keys[seek_result_index]);
+      Slice seek_result_last_key(last_keys[seek_result_index]);
+      iter->UpdateBinarySeekRange(query_key, seek_result_first_key, 
+                                  seek_result_last_key);
+      if (iter->IsLastBinarySeek()) {
+        iter->SwitchToLinearSeekMode();
+        // Special handling for cases where multiple internal keys with the
+        // same user key but different seq_no exist.
+        while (iter->Valid() && icomp.Compare(query_key, seek_result_last_key) > 0) {
+          iter->Next();
+          if (iter->Valid()) {
+            v = iter->value();
+            seek_result_index = reverse_index[v.handle.offset()];
+            seek_result_last_key = Slice(last_keys[seek_result_index]);
           }
-          break;
         }
-        iter->Next();
+        break;
       }
+      iter->Next();
     }
     
     // EXPECT_EQ(separators[expected_index], iter->key().ToString());
@@ -1010,6 +1002,8 @@ TEST_P(PLRIndexBlockTest, PLRIndexValueEncodingTest) {
     if (iter->Valid()) {
       EXPECT_EQ(block_handles[expected_index+1].offset(), v.handle.offset());
       EXPECT_EQ(block_handles[expected_index+1].size(), v.handle.size());
+    } else {
+      EXPECT_EQ(expected_index+1, num_records);
     }
   }
   delete iter;

--- a/table/block_based/block_test.cc
+++ b/table/block_based/block_test.cc
@@ -880,12 +880,12 @@ TEST_P(PLRIndexBlockTest, PLRIndexValueEncodingTest) {
           iter->SwitchToLinearSeekMode();
           // Special handling for cases where multiple internal keys with the
           // same user key but different seq_no exist.
-          // while (icomp.Compare(query_key, seek_result_last_key) > 0) {
-          //   iter->Next();
-          //   v = iter->value();
-          //   seek_result_index = reverse_index[v.handle.offset()];
-          //   seek_result_last_key= Slice(last_keys[seek_result_index]);
-          // }
+          if (icomp.Compare(query_key, seek_result_last_key) > 0) {
+            iter->Next();
+            if (iter->Valid()) {
+              v = iter->value();
+            }
+          }
           break;
         }
         iter->Next();
@@ -929,12 +929,12 @@ TEST_P(PLRIndexBlockTest, PLRIndexValueEncodingTest) {
           iter->SwitchToLinearSeekMode();
           // Special handling for cases where multiple internal keys with the
           // same user key but different seq_no exist.
-          // while (icomp.Compare(query_key, seek_result_last_key) > 0) {
-          //   iter->Next();
-          //   v = iter->value();
-          //   seek_result_index = reverse_index[v.handle.offset()];
-          //   seek_result_last_key= Slice(last_keys[seek_result_index]);
-          // }
+          if (icomp.Compare(query_key, seek_result_last_key) > 0) {
+            iter->Next();
+            if (iter->Valid()) {
+              v = iter->value();
+            }
+          }
           break;
         }
         iter->Next();
@@ -982,8 +982,6 @@ TEST_P(PLRIndexBlockTest, PLRIndexValueEncodingTest) {
           iter->Next();
           if (iter->Valid()) {
             v = iter->value();
-            seek_result_index = reverse_index[v.handle.offset()];
-            seek_result_first_key = Slice(first_keys[seek_result_index]);
           }
         }
         break;

--- a/table/block_based/block_test.cc
+++ b/table/block_based/block_test.cc
@@ -756,12 +756,12 @@ TEST_P(PLRIndexBlockTest, PLRIndexValueEncodingTest) {
     iter->Seek(query_key);
     IndexValue v;
     while (iter->Valid()) {
-      printf("%s\n", iter->GetStateMessage().c_str());
+      // printf("%s\n", iter->GetStateMessage().c_str());
       v = iter->value();
       int seek_result_index = reverse_index[v.handle.offset()];
-      printf("Seek Key: %s\t DataBlk First Key: %s\t DataBlk Last Key: %s\n\n",
-        query_key.ToString().c_str(), first_keys[seek_result_index].c_str(),
-        last_keys[seek_result_index].c_str());
+      // printf("Seek Key: %s\t DataBlk First Key: %s\t DataBlk Last Key: %s\n\n",
+        // query_key.ToString().c_str(), first_keys[seek_result_index].c_str(),
+        // last_keys[seek_result_index].c_str());
       
       // check if the extracted block_handle matches the one in block_handles
       if (seek_result_index == expected_index) {

--- a/table/block_based/block_test.cc
+++ b/table/block_based/block_test.cc
@@ -701,6 +701,7 @@ TEST_P(PLRIndexBlockTest, PLRIndexValueEncodingTest) {
   for (int i = 1; i < num_records; ++i) {
     key = Slice(first_keys[i]);
     builder.AddIndexEntry(nullptr, &key, block_handles[i-1]);
+    builder.OnKeyAdded(key);
   }
   builder.AddIndexEntry(nullptr, nullptr, block_handles[num_records-1]);
 

--- a/table/block_based/block_test.cc
+++ b/table/block_based/block_test.cc
@@ -862,6 +862,18 @@ TEST_P(PLRIndexBlockTest, PLRIndexValueEncodingTest) {
         Slice seek_result_last_key(last_keys[seek_result_index]);
         iter->UpdateBinarySeekRange(query_key, seek_result_first_key, 
                                     seek_result_last_key);
+        if (iter->IsLastBinarySeek()) {
+          iter->SwitchToLinearSeekMode();
+          // Special handling for cases where multiple internal keys with the
+          // same user key but different seq_no exist.
+          while (icomp.Compare(query_key, seek_result_last_key) < 0) {
+            iter->Next();
+            v = iter->value();
+            seek_result_index = reverse_index[v.handle.offset()];
+            seek_result_last_key= Slice(last_keys[seek_result_index]);
+          }
+          break;
+        }
         iter->Next();
       }
     }
@@ -899,6 +911,18 @@ TEST_P(PLRIndexBlockTest, PLRIndexValueEncodingTest) {
         Slice seek_result_last_key(last_keys[seek_result_index]);
         iter->UpdateBinarySeekRange(query_key, seek_result_first_key, 
                                     seek_result_last_key);
+        if (iter->IsLastBinarySeek()) {
+          iter->SwitchToLinearSeekMode();
+          // Special handling for cases where multiple internal keys with the
+          // same user key but different seq_no exist.
+          while (icomp.Compare(query_key, seek_result_last_key) < 0) {
+            iter->Next();
+            v = iter->value();
+            seek_result_index = reverse_index[v.handle.offset()];
+            seek_result_last_key= Slice(last_keys[seek_result_index]);
+          }
+          break;
+        }
         iter->Next();
       }
     }
@@ -912,8 +936,9 @@ TEST_P(PLRIndexBlockTest, PLRIndexValueEncodingTest) {
   iter = nullptr;
 
   // Test 4: Read block contents randomly, using out_of_block_key.
-  // Expected behavior: After several Next(), ultimately the iterator should
-  // find out no index entry matches
+  // Expected behavior: After Seek() and several Next(), ultimately the iterator
+  // should point to the closest data block with first_key > out_of_block_key,
+  // if such block exists (if not exists, becomes !Valid()).
   // printf("Test 4\n");
   iter = new PLRBlockIter(&block_contents, num_records, &icomp);
   for (int i = 0; i < num_records * 2; i++) {
@@ -934,21 +959,31 @@ TEST_P(PLRIndexBlockTest, PLRIndexValueEncodingTest) {
 
       // expectation: our query key should be outside 
       // [seek_result_first_key, seek_result_last_key]
-      if (cmp->Compare(seek_result_first_key, seek_result_last_key) > 0) {
-        assert(!"first_key should be <= last key, something went wrong!");
+      iter->UpdateBinarySeekRange(query_key, seek_result_first_key, 
+                                  seek_result_last_key);
+      if (iter->IsLastBinarySeek()) {
+        iter->SwitchToLinearSeekMode();
+        // Special handling for cases where multiple internal keys with the
+        // same user key but different seq_no exist.
+        while (icomp.Compare(query_key, seek_result_last_key) < 0) {
+          iter->Next();
+          if (!iter->Valid()) {
+            break;
+          }
+          v = iter->value();
+          seek_result_index = reverse_index[v.handle.offset()];
+          seek_result_last_key= Slice(last_keys[seek_result_index]);
+        }
+        break;
       }
-      if (cmp->Compare(query_key, seek_result_first_key) < 0
-          || cmp->Compare(seek_result_last_key, query_key) < 0) {
-        iter->UpdateBinarySeekRange(query_key, seek_result_first_key, 
-                                    seek_result_last_key);
-        iter->Next();
-        continue;
-      }
-      break;
+      iter->Next();
     }
     
     // EXPECT_EQ(separators[expected_index], iter->key().ToString());
-    ASSERT_TRUE(!iter->Valid());
+    if (iter->Valid()) {
+      EXPECT_EQ(block_handles[expected_index+1].offset(), v.handle.offset());
+      EXPECT_EQ(block_handles[expected_index+1].size(), v.handle.size());
+    }
   }
   delete iter;
   iter = nullptr;

--- a/table/block_based/block_test.cc
+++ b/table/block_based/block_test.cc
@@ -635,6 +635,16 @@ class PLRIndexBlockTest
 std::string MakeKeyLookLikeInternalKey(const std::string& key) {
   return key + "12345678";
 }
+string uint2str(uint64_t x) {
+    string s = "";
+    for (int i = 7; i >= 0; --i) {
+        uint64_t mask = 0xFFULL << (8 * i);
+        unsigned char t = (mask & x) >> (8 * i);
+        // cout << mask << endl << (char) t << endl << (unsigned int) t << endl;
+        s += (char) t;
+    }
+    return s;
+}
 // Similar to GenerateRandomIndexEntries but for index block contents.
 void GenerateRandomPLRIndexEntries(std::vector<BlockHandle> *block_handles,
                                 std::vector<std::string> *first_keys,
@@ -644,14 +654,20 @@ void GenerateRandomPLRIndexEntries(std::vector<BlockHandle> *block_handles,
                                 std::map<int, int> &reverse_index,
                                 const int len) {
   Random rnd(42);
+  assert(len > 0);
 
   // For each of `len` blocks, we need to generate a first and last key.
   // Let's generate n*4 random keys, sort them, group into consecutive pairs.
   std::set<std::string> keys;
-  while ((int)keys.size() < len * 4) {
+  while ((int)keys.size() < (len-1) * 4) {
     // PLR index only support key of length 8
     keys.insert(test::RandomKey(&rnd, 8));
   }
+
+  keys.insert(uint2str(18446744073709551612));
+  keys.insert(uint2str(18446744073709551613));
+  keys.insert(uint2str(18446744073709551614));
+  keys.insert(uint2str(18446744073709551615));
 
   uint64_t offset = 0;
   int idx = 0;

--- a/table/block_based/block_test.cc
+++ b/table/block_based/block_test.cc
@@ -805,7 +805,7 @@ TEST_P(PLRIndexBlockTest, PLRIndexValueEncodingTest) {
 
   InternalKeyComparator icomp(options.comparator);
 
-  PLRBlockIter* iter = new PLRBlockIter(&block_contents, num_records, icomp);
+  PLRBlockIter* iter = new PLRBlockIter(&block_contents, num_records, &icomp);
 
 
   // Test 1: Read block contents sequentially.
@@ -831,7 +831,7 @@ TEST_P(PLRIndexBlockTest, PLRIndexValueEncodingTest) {
   // Expected behavior: After several Next(), ultimately the iterator should
   // point to the correct index entry.
   // printf("Test 2\n");
-  iter = new PLRBlockIter(&block_contents, num_records, options.comparator);
+  iter = new PLRBlockIter(&block_contents, num_records, &icomp);
   for (int i = 0; i < num_records * 2; i++) {
     // find a random key in the lookaside array
     int expected_index = rnd.Uniform(num_records);
@@ -872,7 +872,7 @@ TEST_P(PLRIndexBlockTest, PLRIndexValueEncodingTest) {
   // Expected behavior: After several Next(), ultimately the iterator should
   // point to the correct index entry.
   // printf("Test 3\n");
-  iter = new PLRBlockIter(&block_contents, num_records, options.comparator);
+  iter = new PLRBlockIter(&block_contents, num_records, &icomp);
   for (int i = 0; i < num_records * 2; i++) {
     // find a random key in the lookaside array
     int expected_index = rnd.Uniform(num_records);
@@ -909,7 +909,7 @@ TEST_P(PLRIndexBlockTest, PLRIndexValueEncodingTest) {
   // Expected behavior: After several Next(), ultimately the iterator should
   // find out no index entry matches
   // printf("Test 4\n");
-  iter = new PLRBlockIter(&block_contents, num_records, options.comparator);
+  iter = new PLRBlockIter(&block_contents, num_records, &icomp);
   for (int i = 0; i < num_records * 2; i++) {
     // find a random key in the lookaside array
     int expected_index = rnd.Uniform(num_records);

--- a/table/block_based/index_builder.h
+++ b/table/block_based/index_builder.h
@@ -462,9 +462,7 @@ class PLRIndexBuilder: public IndexBuilder {
     IndexBuilder(nullptr),
     helper_(gamma),
     is_first_key_in_first_block_(true),
-    is_non_first_key_(false),
-    duplicated_keys_(),
-    exist_keys_() {}
+    is_non_first_key_(false) {}
 
   // Use helper_ to add a new Point for PLR training of (i+1)-th block. Also,
   // store block_handle of i-th block in helper_. For the last function call, do
@@ -496,6 +494,7 @@ class PLRIndexBuilder: public IndexBuilder {
     Slice user_key = ExtractUserKey(key);
 
     // TODO(fyp): remove after debugging
+    /*
     std::string user_key_str = user_key.ToString();
     if (exist_keys_.count(user_key_str) > 0) {
       duplicated_keys_.insert(user_key_str);
@@ -504,6 +503,7 @@ class PLRIndexBuilder: public IndexBuilder {
       exist_keys_[user_key_str] = std::vector<std::string>();
     }
     exist_keys_[user_key_str].emplace_back(key.ToString());
+    */
 
     if (is_first_key_in_first_block_) {
       assert(!is_non_first_key_);
@@ -530,6 +530,7 @@ class PLRIndexBuilder: public IndexBuilder {
     index_size_ = index_blocks->index_block_contents.size();
 
     // TODO(fyp): remove after debugging
+    /*
     if (!duplicated_keys_.empty()) {
       std::cout << "PLRIndexBuilder: Following user keys are duplicated:" << std::endl;
       for (const auto& k: duplicated_keys_) {
@@ -544,6 +545,7 @@ class PLRIndexBuilder: public IndexBuilder {
         }
       }
     }
+    */
 
     return Status::OK();
   }
@@ -568,7 +570,7 @@ class PLRIndexBuilder: public IndexBuilder {
   bool is_non_first_key_;
 
   // TODO(fyp): remove these after debugging
-  std::set<std::string> duplicated_keys_;
-  std::unordered_map<std::string, std::vector<std::string>> exist_keys_;
+  // std::set<std::string> duplicated_keys_;
+  // std::unordered_map<std::string, std::vector<std::string>> exist_keys_;
 };
 }  // namespace ROCKSDB_NAMESPACE

--- a/table/block_based/index_builder.h
+++ b/table/block_based/index_builder.h
@@ -472,7 +472,7 @@ class PLRIndexBuilder: public IndexBuilder {
   // Note: It seems that both input keys are internal keys, so we need to
   // ExtractUserKey() before storing.
   void AddIndexEntry(std::string* /*last_key_in_current_block*/,
-                    const Slice* first_key_in_next_block,
+                    const Slice* /*first_key_in_next_block*/,
                     const BlockHandle& block_handle) override {
     /* TODO(fyp): remove this:
     if (first_key_in_next_block != nullptr) {
@@ -500,7 +500,7 @@ class PLRIndexBuilder: public IndexBuilder {
       return;
     }
     if (is_non_first_key_) {
-      helper.AddPLRIntermediateTrainingPoint(ExtractUserKey(key));
+      helper_.AddPLRIntermediateTrainingPoint(ExtractUserKey(key));
     }
     else {
       helper_.AddPLRTrainingPoint(ExtractUserKey(key));

--- a/table/block_based/index_builder.h
+++ b/table/block_based/index_builder.h
@@ -462,7 +462,9 @@ class PLRIndexBuilder: public IndexBuilder {
     IndexBuilder(nullptr),
     helper_(gamma),
     is_first_key_in_first_block_(true),
-    is_non_first_key_(false) {}
+    is_non_first_key_(false),
+    duplicated_keys_(),
+    exist_keys_() {}
 
   // Use helper_ to add a new Point for PLR training of (i+1)-th block. Also,
   // store block_handle of i-th block in helper_. For the last function call, do
@@ -491,19 +493,31 @@ class PLRIndexBuilder: public IndexBuilder {
   //
   // Note: It seems input key is an internal key, so we need ExtractUserKey().
   void OnKeyAdded(const Slice& key) override {
+    Slice user_key = ExtractUserKey(key);
+
+    // TODO(fyp): remove after debugging
+    std::string user_key_str = user_key.ToString();
+    if (exist_keys_.count(user_key_str) > 0) {
+      duplicated_keys_.insert(user_key_str);
+    }
+    else {
+      exist_keys_[user_key_str] = std::vector<std::string>();
+    }
+    exist_keys_[user_key_str].emplace_back(key.ToString());
+
     if (is_first_key_in_first_block_) {
       assert(!is_non_first_key_);
       is_first_key_in_first_block_ = false;
-      assert(ExtractUserKey(key).size() <= 8);
-      helper_.AddPLRTrainingPoint(ExtractUserKey(key));
+      assert(user_key.size() <= 8);
+      helper_.AddPLRTrainingPoint(user_key);
       is_non_first_key_ = true;
       return;
     }
     if (is_non_first_key_) {
-      helper_.AddPLRIntermediateTrainingPoint(ExtractUserKey(key));
+      helper_.AddPLRIntermediateTrainingPoint(user_key);
     }
     else {
-      helper_.AddPLRTrainingPoint(ExtractUserKey(key));
+      helper_.AddPLRTrainingPoint(user_key);
       is_non_first_key_ = true;
     }
   }
@@ -514,6 +528,22 @@ class PLRIndexBuilder: public IndexBuilder {
 
     index_blocks->index_block_contents = helper_.Finish();
     index_size_ = index_blocks->index_block_contents.size();
+
+    // TODO(fyp): remove after debugging
+    if (!duplicated_keys_.empty()) {
+      std::cout << "PLRIndexBuilder: Following user keys are duplicated:" << std::endl;
+      for (const auto& k: duplicated_keys_) {
+        std::cout << "User key: " << k << std::endl;
+        for (const auto& key_string: exist_keys_[k]) {
+          std::cout << "internal key string representation: " << key_string << std::endl;
+          std::cout << "internal key byte representation: ";
+          for (size_t i = 0; i < key_string.size(); ++i) {
+            std::cout << (unsigned int) ((unsigned char) key_string[i]) << ";";
+          }
+          std::cout << std::endl;
+        }
+      }
+    }
 
     return Status::OK();
   }
@@ -536,5 +566,9 @@ class PLRIndexBuilder: public IndexBuilder {
   // then set this flag to false.
   bool is_first_key_in_first_block_;
   bool is_non_first_key_;
+
+  // TODO(fyp): remove these after debugging
+  std::set<std::string> duplicated_keys_;
+  std::unordered_map<std::string, std::vector<std::string>> exist_keys_;
 };
 }  // namespace ROCKSDB_NAMESPACE

--- a/table/block_based/index_builder.h
+++ b/table/block_based/index_builder.h
@@ -461,7 +461,8 @@ class PLRIndexBuilder: public IndexBuilder {
   PLRIndexBuilder(double gamma): 
     IndexBuilder(nullptr),
     helper_(gamma),
-    is_first_key_in_first_block_(true) {}
+    is_first_key_in_first_block_(true),
+    is_non_first_key_(false) {}
 
   // Use helper_ to add a new Point for PLR training of (i+1)-th block. Also,
   // store block_handle of i-th block in helper_. For the last function call, do
@@ -473,13 +474,16 @@ class PLRIndexBuilder: public IndexBuilder {
   void AddIndexEntry(std::string* /*last_key_in_current_block*/,
                     const Slice* first_key_in_next_block,
                     const BlockHandle& block_handle) override {
+    /* TODO(fyp): remove this:
     if (first_key_in_next_block != nullptr) {
       // current AddIndexEntry() call is not processing with:
       // current_block = last data block
       assert(ExtractUserKey(*first_key_in_next_block).size() <= 8);
       helper_.AddPLRTrainingPoint(ExtractUserKey(*first_key_in_next_block));
     }
+    */
     helper_.AddHandle(block_handle);
+    is_non_first_key_ = false;
   }
   
   // If it is the first every key from the first data block, use helper_ to add
@@ -488,9 +492,19 @@ class PLRIndexBuilder: public IndexBuilder {
   // Note: It seems input key is an internal key, so we need ExtractUserKey().
   void OnKeyAdded(const Slice& key) override {
     if (is_first_key_in_first_block_) {
+      assert(!is_non_first_key_);
       is_first_key_in_first_block_ = false;
       assert(ExtractUserKey(key).size() <= 8);
       helper_.AddPLRTrainingPoint(ExtractUserKey(key));
+      is_non_first_key_ = true;
+      return;
+    }
+    if (is_non_first_key_) {
+      helper.AddPLRIntermediateTrainingPoint(ExtractUserKey(key));
+    }
+    else {
+      helper_.AddPLRTrainingPoint(ExtractUserKey(key));
+      is_non_first_key_ = true;
     }
   }
 
@@ -521,5 +535,6 @@ class PLRIndexBuilder: public IndexBuilder {
   // If true, OnKeyAdded() will use helper_ to add an Point for PLR training
   // then set this flag to false.
   bool is_first_key_in_first_block_;
+  bool is_non_first_key_;
 };
 }  // namespace ROCKSDB_NAMESPACE

--- a/table/block_based/learned_index/plr/plr_block_iter.cc
+++ b/table/block_based/learned_index/plr/plr_block_iter.cc
@@ -229,14 +229,18 @@ void PLRBlockIter::SetCurrentIndexValue() {
 	// }
 }
 
-// This function should be called if the Seek key does not exist in the current_
-// data block in binary seek mode. It updates the seek range correspondingly,
-// such that the next PLRBlockIter::Next() will update current_ to a correct
-// value.
+// This function updates the seek range correspondingly, such that the 
+// next PLRBlockIter::Next() will update current_ to a correct value.
+//
+// The primary goal of this function is to update current_ until it points to
+// the block that contains the first occurrence of the user key in seek_key.
+// However, there may have optimizations that try to make current_ pointing to
+// a block that contains an internal key with same user key as seek_key and
+// a seqno closer to seek_key (on L.H.S.).
 //
 // Note: This function assumes input data_block first/last keys are the keys of
 // the current data block (as pointed by current_).
-// Note: Only accepts user keys, not internal keys.
+// Note: Only accepts internal keys.
 //
 // REQUIRES: Valid()
 // REQUIRES: binary seek mode
@@ -245,32 +249,78 @@ void PLRBlockIter::UpdateBinarySeekRange(const Slice& seek_key,
 																					const Slice& data_block_last_key) {
 	assert(Valid());
 	assert(seek_mode_ == SeekMode::kBinarySeek);
+
+	ParsedInternalKey parsed_seek_key;
+	if (!ParseInternalKey(seek_key, &parsed_seek_key)) {
+		assert(false);
+	}
+	ParsedInternalKey parsed_first_key;
+	if (!ParseInternalKey(data_block_first_key, &parsed_first_key)) {
+		assert(false);
+	}
+	ParsedInternalKey parsed_last_key;
+	if (!ParseInternalKey(data_block_last_key, &parsed_last_key)) {
+		assert(false);
+	}
+
 	// Slice first_user_key = ExtractUserKey(data_block_first_key);
 	// Slice last_user_key = ExtractUserKey(data_block_last_key);
 	// Slice seek_user_key = ExtractUserKey(seek_key);
 
-	assert(user_comparator_->Compare(data_block_first_key, 
-																	 data_block_last_key) <= 0);
+	assert(internal_key_comparator_->user_comparator()->
+					Compare(parsed_first_key.user_key, parsed_last_key.user_key) <= 0);
 	
 	// Case 1: Seek key > All keys in current data block.
-	if (user_comparator_->Compare(data_block_last_key, seek_key) < 0) {
+	if (internal_key_comparator_->user_comparator()->
+				Compare(parsed_last_key.user_key, parsed_seek_key.user_key) < 0) {
 		SetBeginBlockAsCurrent();
 		return;
 	}
 
 	// Case 2: Seek key < All keys in current data block.
-	if (user_comparator_->Compare(seek_key, data_block_first_key) < 0) {
+	if (internal_key_comparator_->user_comparator()->
+				Compare(parsed_seek_key.user_key, parsed_first_key.user_key) < 0) {
 		SetEndBlockAsCurrent();
 		return;
 	}
 
 	// Case 3: First key in data block <= Seek key <= Last key in data block.
 	// Then Seek key must lie within the current data block if it exists.
-	// However, this function is only called if the Seek key does not exist.
-	// This implies the Seek key does not exist in the SSTable.
-	//
-	// Then we can adjust the seek range such that after the next Next(),
-	// the iterator becomes !Valid().
+
+	if (internal_key_comparator_->user_comparator()->
+				Compare(parsed_first_key.user_key, parsed_seek_key.user_key) < 0) {
+		// Case 3.1: first_key.user_key < target.user_key <= last_key.user_key
+
+		if (internal_key_comparator_->user_comparator()->
+					Compare(parsed_seek_key.user_key, parsed_last_key.user_key) < 0) {
+			// Case 3.1.1: first_key.user_key < target.user_key < last_key.user_key
+			// Seek key (internal key) must exist in this block.
+			// Then we can adjust the seek range such that after the next Next(),
+			// the iterator becomes !Valid().
+			begin_block_ = end_block_+1;
+			assert(IsLastBinarySeek());
+			return;
+		}
+
+		// Case 3.1.2: first_key.user_key < target.user_key = last_key.user_key
+		// begin_block_ = current_;
+		// Start linear seek from current_.
+		begin_block_ = end_block_+1;
+		assert(IsLastBinarySeek());
+		return;
+	}
+
+	// Case 3.2: first_key.user_key = target.user_key <= last_key.user_key
+	if (internal_key_comparator_.Compare(data_block_first_key, seek_key) > 0) {
+		// Case 3.2.1: first_key.seqno > target.seqno
+		// If IsLastBinarySeek(), continue linear seek in current_ though
+		// there should be no matches. Otherwise, continue binary seek at L.H.S.
+		SetEndBlockAsCurrent();
+		return;
+	}
+
+	// Case 3.2.2: first_key.seqno <= target.seqno
+	// Start linear seek from current_.
 	begin_block_ = end_block_+1;
 	assert(IsLastBinarySeek());
 }

--- a/table/block_based/learned_index/plr/plr_block_iter.cc
+++ b/table/block_based/learned_index/plr/plr_block_iter.cc
@@ -324,8 +324,8 @@ Status PLRBlockHelper::PredictBlockRange(const Slice& target,
 	end_block = std::max<uint64_t>(0, 
 																	std::min(num_data_blocks_ - 1, static_cast<uint64_t>(range.second)));
 	// TODO(fyp): debug only:
-	begin_block = 0;
-	end_block = num_data_blocks_ - 1;
+	// begin_block = 0;
+	// end_block = num_data_blocks_ - 1;
 	return Status::OK();
 }
 

--- a/table/block_based/learned_index/plr/plr_block_iter.cc
+++ b/table/block_based/learned_index/plr/plr_block_iter.cc
@@ -323,6 +323,9 @@ Status PLRBlockHelper::PredictBlockRange(const Slice& target,
 																	std::min(num_data_blocks_ - 1, static_cast<uint64_t>(range.first)));
 	end_block = std::max<uint64_t>(0, 
 																	std::min(num_data_blocks_ - 1, static_cast<uint64_t>(range.second)));
+	// TODO(fyp): debug only:
+	begin_block = 0;
+	end_block = num_data_blocks_ - 1;
 	return Status::OK();
 }
 

--- a/table/block_based/learned_index/plr/plr_block_iter.cc
+++ b/table/block_based/learned_index/plr/plr_block_iter.cc
@@ -329,9 +329,9 @@ Status PLRBlockHelper::PredictBlockRange(const Slice& target,
 	assert(range.first <= range.second);
 
 	begin_block = std::max<uint64_t>(0, 
-																	std::min(num_data_blocks_ - 1, range.first));
+																	std::min(num_data_blocks_ - 1, static_cast<uint64_t>(range.first)));
 	end_block = std::max<uint64_t>(0, 
-																	std::min(num_data_blocks_ - 1, range.second));
+																	std::min(num_data_blocks_ - 1, static_cast<uint64_t>(range.second)));
 	return Status::OK();
 }
 

--- a/table/block_based/learned_index/plr/plr_block_iter.cc
+++ b/table/block_based/learned_index/plr/plr_block_iter.cc
@@ -293,7 +293,7 @@ Status PLRBlockHelper::DecodePLRBlock(const Slice& data) {
 	// Extract the substring corr. to PLR Segments and Data block sizes
 	const size_t total_length = data.size();
 
-	const size_t block_handles_length = kParamSize * (num_data_blocks_ + 1);
+	const size_t block_handles_length = sizeof(uint64_t) * (num_data_blocks_ + 1);
 	assert(total_length > block_handles_length);
 
 	const size_t plr_segments_length = total_length - block_handles_length;
@@ -307,7 +307,7 @@ Status PLRBlockHelper::DecodePLRBlock(const Slice& data) {
 
 	// Initialize model_ and handle_calculator_
 	model_.reset(
-		new PLRDataRep<EncodedStrBaseType, double>(encoded_plr_segments));
+		new PLRDataRep<EncodedStrBaseType, long double>(encoded_plr_segments));
 	handle_calculator_.reset(
 		new BlockHandleCalculator(encoded_block_handles, num_data_blocks_));
 	
@@ -325,7 +325,7 @@ Status PLRBlockHelper::PredictBlockRange(const Slice& target,
 	KeyInternalRep key = stringToNumber<KeyInternalRep>(target_str);
 
 	// Get range, check for invalid range
-	auto range =  model_->GetValue(key);
+	auto range =  model_->GetValue((EncodedStrBaseType) key);
 	assert(range.first <= range.second);
 
 	begin_block = std::max<uint64_t>(0, 

--- a/table/block_based/learned_index/plr/plr_block_iter.cc
+++ b/table/block_based/learned_index/plr/plr_block_iter.cc
@@ -221,12 +221,6 @@ void PLRBlockIter::SetCurrentIndexValue() {
 	}
 
 	value_.handle = handle;
-
-	// TODO(fyp): What is this??
-	// if (seek_mode_ == SeekMode::kBinarySeek) {
-	// 	// Update the begin_block_ or end_block_, based on current block value.
-	// 	// do nothing currently, unless have time to change SetBeginBlockAsCurrent()
-	// }
 }
 
 // This function updates the seek range correspondingly, such that the 
@@ -324,6 +318,7 @@ Status PLRBlockHelper::PredictBlockRange(const Slice& target,
 	auto range =  model_->GetValue(static_cast<EncodedStrBaseType>(key));
 	assert(range.first <= range.second);
 
+	assert(num_data_blocks_ > 0);
 	begin_block = std::max<uint64_t>(0, 
 																	std::min(num_data_blocks_ - 1, static_cast<uint64_t>(range.first)));
 	end_block = std::max<uint64_t>(0, 

--- a/table/block_based/learned_index/plr/plr_block_iter.cc
+++ b/table/block_based/learned_index/plr/plr_block_iter.cc
@@ -4,10 +4,10 @@ namespace ROCKSDB_NAMESPACE {
 
 bool PLRBlockIter::Valid() const {
 	if (current_ == invalid_block_number_) {
-		op_logs += "Valid();";
+		op_logs.append("Valid();");
 	}
 	else {
-		op_logs += "InValid();";
+		op_logs.append("InValid();");
 	}
 	return current_ != invalid_block_number_;
 }
@@ -102,7 +102,7 @@ void PLRBlockIter::Seek(const Slice& target) {
 	
 	Slice seek_key = ExtractUserKey(target);
 	for (size_t idx = 0; idx < seek_key.size(); ++idx) {
-		op_logs += std::to_string((unsigned int) ((unsigned char) seek_key[idx])) + ";"
+		op_logs += std::to_string((unsigned int) ((unsigned char) seek_key[idx])) + ";";
 	}
 	op_logs += "):[";
 
@@ -210,12 +210,12 @@ void PLRBlockIter::Prev() {
 Slice PLRBlockIter::key() const {
 	assert(Valid());
 	if (is_key_set_) {
-		op_logs += "key()[";
+		op_logs.append("key()[");
 		Slice k = key_.GetKey();
 		for (size_t idx = 0; idx < k.size(); ++idx) {
-			op_logs += std::to_string((unsigned int) ((unsigned char) k[idx])) + ";"
+			op_logs.append(std::to_string((unsigned int) ((unsigned char) k[idx])) + ";");
 		}
-		op_logs += "];";
+		op_logs.append("];");
 		return key_.GetKey();
 	}
 	return Slice(key_extraction_not_supported_);

--- a/table/block_based/learned_index/plr/plr_block_iter.cc
+++ b/table/block_based/learned_index/plr/plr_block_iter.cc
@@ -311,7 +311,7 @@ void PLRBlockIter::UpdateBinarySeekRange(const Slice& seek_key,
 	}
 
 	// Case 3.2: first_key.user_key = target.user_key <= last_key.user_key
-	if (internal_key_comparator_.Compare(data_block_first_key, seek_key) > 0) {
+	if (internal_key_comparator_->Compare(data_block_first_key, seek_key) > 0) {
 		// Case 3.2.1: first_key.seqno > target.seqno
 		// If IsLastBinarySeek(), continue linear seek in current_ though
 		// there should be no matches. Otherwise, continue binary seek at L.H.S.

--- a/table/block_based/learned_index/plr/plr_block_iter.cc
+++ b/table/block_based/learned_index/plr/plr_block_iter.cc
@@ -330,7 +330,8 @@ Status PLRBlockHelper::PredictBlockRange(const Slice& target,
 
 	begin_block = std::max<uint64_t>(0, 
 																	std::min(num_data_blocks_ - 1, range.first));
-	end_block = std::min(num_data_blocks_ - 1, range.second);
+	end_block = std::max<uint64_t>(0, 
+																	std::min(num_data_blocks_ - 1, range.second));
 	return Status::OK();
 }
 

--- a/table/block_based/learned_index/plr/plr_block_iter.cc
+++ b/table/block_based/learned_index/plr/plr_block_iter.cc
@@ -325,7 +325,7 @@ Status PLRBlockHelper::PredictBlockRange(const Slice& target,
 	KeyInternalRep key = stringToNumber<KeyInternalRep>(target_str);
 
 	// Get range, check for invalid range
-	auto range =  model_->GetValue((EncodedStrBaseType) key);
+	auto range =  model_->GetValue(static_cast<EncodedStrBaseType>(key));
 	assert(range.first <= range.second);
 
 	begin_block = std::max<uint64_t>(0, 

--- a/table/block_based/learned_index/plr/plr_block_iter.h
+++ b/table/block_based/learned_index/plr/plr_block_iter.h
@@ -28,6 +28,11 @@ class PLRBlockHelper {
 		model_(nullptr),
 		handle_calculator_(nullptr),
 		num_data_blocks_(num_data_blocks) {
+		// TODO(fyp): If num_data_blocks == 0, it's possible that sstable only
+		// stores info. about deleted data(?) without any data block.
+		// In this case, we may need to make plr block iter do nothing when
+		// num_data_block is 0. But then will iiter still be invoked?
+		assert(num_data_blocks > 0);
 		DecodePLRBlock(data); 
 	}
 

--- a/table/block_based/learned_index/plr/plr_block_iter.h
+++ b/table/block_based/learned_index/plr/plr_block_iter.h
@@ -52,12 +52,12 @@ class PLRBlockHelper {
 
  private:
 	typedef uint64_t KeyInternalRep;
-	typedef uint64_t EncodedStrBaseType;
+	typedef long double EncodedStrBaseType;
 	static const size_t kKeySize = sizeof(KeyInternalRep);
 	static const size_t kParamSize = sizeof(EncodedStrBaseType);
 
 	// TODO(fyp): Verify member types
-	std::unique_ptr<PLRDataRep<EncodedStrBaseType, double>> model_;
+	std::unique_ptr<PLRDataRep<EncodedStrBaseType, long double>> model_;
 	std::unique_ptr<BlockHandleCalculator> handle_calculator_;
 	const uint64_t num_data_blocks_;
 

--- a/table/block_based/learned_index/plr/plr_block_iter.h
+++ b/table/block_based/learned_index/plr/plr_block_iter.h
@@ -241,7 +241,7 @@ class PLRBlockIter : public InternalIteratorBase<IndexValue> {
 	const InternalKeyComparator* internal_key_comparator_;
 	Status status_;
 
-	std::string op_logs;
+	mutable std::string op_logs;
 
 	std::unique_ptr<PLRBlockHelper> helper_;
 

--- a/table/block_based/learned_index/plr/plr_block_iter.h
+++ b/table/block_based/learned_index/plr/plr_block_iter.h
@@ -92,6 +92,7 @@ class PLRBlockIter : public InternalIteratorBase<IndexValue> {
 		value_(),
 		internal_key_comparator_(internal_key_comparator),
 		status_(),
+		op_logs(),
 		helper_(std::unique_ptr<PLRBlockHelper>(
 			new PLRBlockHelper(num_data_blocks, data_)))
 		{
@@ -198,6 +199,8 @@ class PLRBlockIter : public InternalIteratorBase<IndexValue> {
 
 	void SetStatus(Status s) { status_ = s; }
 
+	std::string GetOpLogs() { return op_logs; }
+
  private:
 	enum class SeekMode : char {
 		kUnknown = 0x00,
@@ -238,6 +241,8 @@ class PLRBlockIter : public InternalIteratorBase<IndexValue> {
 	const InternalKeyComparator* internal_key_comparator_;
 	Status status_;
 
+	std::string op_logs;
+
 	std::unique_ptr<PLRBlockHelper> helper_;
 
 	inline bool IsLastLinearSeek() const {
@@ -250,6 +255,7 @@ class PLRBlockIter : public InternalIteratorBase<IndexValue> {
 
 	inline void SetBeginBlockAsCurrent() {
 		begin_block_ = current_ + 1;
+		op_logs += "SetBeginBlockAsCurrent();";
 	}
 
 	inline void SetEndBlockAsCurrent() {
@@ -264,6 +270,7 @@ class PLRBlockIter : public InternalIteratorBase<IndexValue> {
 		else {
 			end_block_ = current_ - 1;
 		}
+		op_logs += "SetEndBlockAsCurrent();";
 	}
 
 	void SetCurrentIndexValue();

--- a/table/block_based/learned_index/plr/plr_block_iter.h
+++ b/table/block_based/learned_index/plr/plr_block_iter.h
@@ -75,7 +75,7 @@ class PLRBlockHelper {
 class PLRBlockIter : public InternalIteratorBase<IndexValue> {
  public:
 	PLRBlockIter(const BlockContents* contents, const uint64_t num_data_blocks, 
-							const Comparator* user_comparator) :
+							const InternalKeyComparator* internal_key_comparator) :
 		InternalIteratorBase<IndexValue>(),
 		seek_mode_(SeekMode::kUnknown),
 		data_(contents->data),
@@ -85,7 +85,7 @@ class PLRBlockIter : public InternalIteratorBase<IndexValue> {
 		key_(),
 		is_key_set_(false),
 		value_(),
-		user_comparator_(user_comparator),
+		internal_key_comparator_(internal_key_comparator),
 		status_(),
 		helper_(std::unique_ptr<PLRBlockHelper>(
 			new PLRBlockHelper(num_data_blocks, data_)))
@@ -146,6 +146,7 @@ class PLRBlockIter : public InternalIteratorBase<IndexValue> {
 	void UpdateBinarySeekRange(const Slice& seek_key,
 															const Slice& data_block_first_key,
 															const Slice& data_block_last_key);
+
 	std::string GetStateMessage() {
 		return std::string("PLRBlockIter::GetStateMessage():\n")
 						+ "begin_block_: " + std::to_string(begin_block_) 
@@ -153,7 +154,7 @@ class PLRBlockIter : public InternalIteratorBase<IndexValue> {
 						+ "; end_block_: " + std::to_string(end_block_);
 	}
 
-	// The following public functions are used by BlockBasedTableIterator.
+	// The following public functions are used by BlockBasedTable(Iterator).
 
 	// Usage: Set key_ as current_ data block last key.
 	// TODO(fyp): Not sure if this will cause memory leak or not.
@@ -227,7 +228,7 @@ class PLRBlockIter : public InternalIteratorBase<IndexValue> {
 	// Return true if key_ is set and active; false otherwise. 
 	bool is_key_set_;
 	IndexValue value_;
-	const Comparator* user_comparator_;
+	const InternalKeyComparator* internal_key_comparator_;
 	Status status_;
 
 	std::unique_ptr<PLRBlockHelper> helper_;

--- a/table/block_based/learned_index/plr/plr_block_iter.h
+++ b/table/block_based/learned_index/plr/plr_block_iter.h
@@ -191,6 +191,8 @@ class PLRBlockIter : public InternalIteratorBase<IndexValue> {
 
 	void SeekEndBlock();
 
+	void SetStatus(Status s) { status_ = s; }
+
  private:
 	enum class SeekMode : char {
 		kUnknown = 0x00,

--- a/table/block_based/learned_index/plr/plr_index_builder_helper.h
+++ b/table/block_based/learned_index/plr/plr_index_builder_helper.h
@@ -70,6 +70,14 @@ class PLRBuilderHelper {
     trainer_.process(p);
   }
 
+  void AddPLRIntermediateTrainingPoint(const Slice& non_first_key) {
+    assert(!finished_);
+
+    double key_floating_rep = Str2Double(
+      non_first_key.data(), non_first_key.size());
+    trainer_.AddNonFirstKeyPoint(key_floating_rep);
+  }
+
   // Add the current data block handle's size() to encoder
   void AddHandle(const BlockHandle& block_handle) {
     if (!added_first_data_block_offset_) {

--- a/table/block_based/learned_index/plr/plr_index_builder_helper.h
+++ b/table/block_based/learned_index/plr/plr_index_builder_helper.h
@@ -75,7 +75,7 @@ class PLRBuilderHelper {
 
     double key_floating_rep = Str2Double(
       non_first_key.data(), non_first_key.size());
-    trainer_.AddNonFirstKeyPoint(key_floating_rep);
+    trainer_.AddNonFirstKey(key_floating_rep);
   }
 
   // Add the current data block handle's size() to encoder

--- a/table/block_based/learned_index/plr/plr_index_builder_helper.h
+++ b/table/block_based/learned_index/plr/plr_index_builder_helper.h
@@ -64,16 +64,16 @@ class PLRBuilderHelper {
   void AddPLRTrainingPoint(const Slice& first_key_in_data_block) {
     assert(!finished_);
     
-    double first_key_floating_rep = Str2Double(
+    long double first_key_floating_rep = Str2Double(
       first_key_in_data_block.data(), first_key_in_data_block.size());
-    Point<double> p(first_key_floating_rep, num_data_blocks_++);
+    Point<long double> p(first_key_floating_rep, num_data_blocks_++);
     trainer_.process(p);
   }
 
   void AddPLRIntermediateTrainingPoint(const Slice& non_first_key) {
     assert(!finished_);
 
-    double key_floating_rep = Str2Double(
+    long double key_floating_rep = Str2Double(
       non_first_key.data(), non_first_key.size());
     trainer_.AddNonFirstKey(key_floating_rep);
   }
@@ -93,8 +93,8 @@ class PLRBuilderHelper {
   Slice Finish() {
     assert(!finished_);
 
-    std::vector<Segment<uint64_t, double>> segments = trainer_.finish();
-    auto plr_param_encoder = PLRDataRep<uint64_t, double>(gamma_, segments);
+    std::vector<Segment<long double, long double>> segments = trainer_.finish();
+    auto plr_param_encoder = PLRDataRep<long double, long double>(gamma_, segments);
 
     buffer_ = plr_param_encoder.Encode();
     data_block_handles_encoder_.Encode(&buffer_);
@@ -105,8 +105,8 @@ class PLRBuilderHelper {
  private:
   // TODO(fyp): reading non-active member from union is UB, although most
   // compiler defined its behavior as a non-standard extension?
-  double Str2Double(const char* str, size_t size) {
-    assert(size <= 8);
+  long double Str2Double(const char* str, size_t size) {
+    // assert(size <= 8);
     // uint64_t int_rep = 0;
     // for (size_t i = 0; i < size; ++i) {
     //   int_rep <<= 8;
@@ -116,10 +116,11 @@ class PLRBuilderHelper {
     std::string s(str, size);
 
     uint64_t int_rep = stringToNumber<uint64_t>(s);
-    return (double) int_rep;
+    return (long double) int_rep;
   }
 
-  GreedyPLR<uint64_t, double> trainer_;
+  // GreedyPLR<uint64_t, double> trainer_;
+  GreedyPLR<long double, long double> trainer_;
   DataBlockHandlesEncoder data_block_handles_encoder_;
   uint32_t num_data_blocks_;
   double gamma_;

--- a/table/block_based/learned_index/plr/plr_index_builder_helper.h
+++ b/table/block_based/learned_index/plr/plr_index_builder_helper.h
@@ -127,8 +127,9 @@ class PLRBuilderHelper {
     finished_ = true;
 
     // TODO(fyp): remove after debugging
+    /*
     if (!duplicated_keys_.empty()) {
-      std::cout << "Following keys are duplicated:" << std::endl;
+      std::cout << "PLRBuilderHelper: Following keys are duplicated:" << std::endl;
       for (const auto& k: duplicated_keys_) {
         std::cout << "Key double representation: " << k << std::endl;
         for (const auto& key_string: exist_keys_[k]) {
@@ -141,6 +142,7 @@ class PLRBuilderHelper {
         }
       }
     }
+    */
 
     return Slice(buffer_);
   }

--- a/table/block_based/learned_index/plr/plr_index_builder_helper.h
+++ b/table/block_based/learned_index/plr/plr_index_builder_helper.h
@@ -2,10 +2,12 @@
 
 #include <vector>
 // TODO(fyp): remove after dubugging
+/*
 #include <utility>
 #include <set>
 #include <unordered_map>
 #include <iostream>
+*/
 
 #include "table/format.h"
 #include "table/block_based/learned_index/plr/external/plr/library.h"
@@ -60,9 +62,7 @@ class PLRBuilderHelper {
     gamma_(gamma),
     buffer_(),
     added_first_data_block_offset_(false),
-    finished_(false),
-    duplicated_keys_(),
-    exist_keys_() {}
+    finished_(false) {}
 
   // Add a new point to trainer_. Increment num_data_blocks by 1.
   // This assumes AddPLRTrainingPoint() is called in the sorted order of
@@ -76,6 +76,7 @@ class PLRBuilderHelper {
     Point<long double> p(first_key_floating_rep, num_data_blocks_++);
     trainer_.process(p);
     // TODO(fyp): remove after debugging
+    /*
     if (exist_keys_.count(first_key_floating_rep) > 0) {
       duplicated_keys_.insert(first_key_floating_rep);
     }
@@ -83,6 +84,7 @@ class PLRBuilderHelper {
       exist_keys_[first_key_floating_rep] = std::vector<std::string>();
     }
     exist_keys_[first_key_floating_rep].emplace_back(first_key_in_data_block.ToString());
+    */
   }
 
   void AddPLRIntermediateTrainingPoint(const Slice& non_first_key) {
@@ -91,6 +93,7 @@ class PLRBuilderHelper {
     long double key_floating_rep = Str2Double(
       non_first_key.data(), non_first_key.size());
     // TODO(fyp): remove after debugging
+    /*
     if (exist_keys_.count(key_floating_rep) > 0) {
       duplicated_keys_.insert(key_floating_rep);
       exist_keys_[key_floating_rep].emplace_back(non_first_key.ToString());
@@ -100,6 +103,7 @@ class PLRBuilderHelper {
       exist_keys_[key_floating_rep] = std::vector<std::string>();
       exist_keys_[key_floating_rep].emplace_back(non_first_key.ToString());
     }
+    */
 
     trainer_.AddNonFirstKey(key_floating_rep);
   }
@@ -176,7 +180,7 @@ class PLRBuilderHelper {
   bool added_first_data_block_offset_;
   bool finished_;
   // TODO(fyp): remove these after debugging
-  std::set<long double> duplicated_keys_;
-  std::unordered_map<long double, std::vector<std::string>> exist_keys_;
+  // std::set<long double> duplicated_keys_;
+  // std::unordered_map<long double, std::vector<std::string>> exist_keys_;
 };
 }

--- a/table/block_based/learned_index/plr/plr_index_builder_helper.h
+++ b/table/block_based/learned_index/plr/plr_index_builder_helper.h
@@ -2,7 +2,7 @@
 
 #include <vector>
 // TODO(fyp): remove after dubugging
-#include <pair>
+#include <utility>
 #include <set>
 #include <iostream>
 

--- a/table/block_based/learned_index/plr/plr_index_builder_helper.h
+++ b/table/block_based/learned_index/plr/plr_index_builder_helper.h
@@ -116,7 +116,7 @@ class PLRBuilderHelper {
     std::string s(str, size);
 
     uint64_t int_rep = stringToNumber<uint64_t>(s);
-    return (long double) int_rep;
+    return static_cast<long double>(int_rep);
   }
 
   // GreedyPLR<uint64_t, double> trainer_;

--- a/table/block_based/learned_index/plr/plr_index_builder_helper.h
+++ b/table/block_based/learned_index/plr/plr_index_builder_helper.h
@@ -93,12 +93,12 @@ class PLRBuilderHelper {
     // TODO(fyp): remove after debugging
     if (exist_keys_.count(key_floating_rep) > 0) {
       duplicated_keys_.insert(key_floating_rep);
-      exist_keys_[key_floating_rep].emplace_back(first_key_in_data_block.ToString());
+      exist_keys_[key_floating_rep].emplace_back(non_first_key.ToString());
       return;
     }
     else {
       exist_keys_[key_floating_rep] = std::vector<std::string>();
-      exist_keys_[key_floating_rep].emplace_back(first_key_in_data_block.ToString());
+      exist_keys_[key_floating_rep].emplace_back(non_first_key.ToString());
     }
 
     trainer_.AddNonFirstKey(key_floating_rep);

--- a/table/table_test.cc
+++ b/table/table_test.cc
@@ -2525,12 +2525,12 @@ void TableTest::PLRIndexTestManySameUserKeys(BlockBasedTableOptions table_option
   }
 
   // find the first_keys of prefixes
-  std::vector<std::string> upper_bound = {keys[1], keys[2], keys[12], 
-                                          keys[20], std::string("")};
+  std::vector<std::string> upper_bound = {keys[1], keys[11], keys[19], 
+                                          keys[29], std::string("")};
   std::vector<std::string> ub_answers = {data_block_values[1], 
-                                         data_block_values[2], 
-                                         data_block_values[12], 
-                                         data_block_values[20],
+                                         data_block_values[11], 
+                                         data_block_values[19], 
+                                         data_block_values[29],
                                          std::string("")};
 
   for (size_t i = 0; i < prefixes.size(); ++i) {

--- a/table/table_test.cc
+++ b/table/table_test.cc
@@ -2464,7 +2464,7 @@ void TableTest::PLRIndexTestManySameUserKeys(BlockBasedTableOptions table_option
   std::vector<std::string> keys;
   stl_wrappers::KVMap kvmap;
   Options options;
-  options.prefix_extractor.reset(NewFixedPrefixTransform(3));
+  options.prefix_extractor.reset(NewFixedPrefixTransform(4));
   table_options.block_size = 1700;
   table_options.block_cache = NewLRUCache(1024, 4);
   table_options.plr_index_block_gamma = gamma;
@@ -2583,38 +2583,33 @@ void TableTest::PLRIndexTestManySameUserKeys(BlockBasedTableOptions table_option
   }
 
   // seek same user keys with different seq nos
-  std::vector<Slice> seek_keys = {
-    InternalKey("00150000", 10000, kTypeValue).Encode(),
-    InternalKey("00150000", 9990, kTypeValue).Encode(),
-    InternalKey("00150000", 9010, kTypeValue).Encode(),
-    InternalKey("00150000", 9000, kTypeValue).Encode(),
-    InternalKey("00150000", 8990, kTypeValue).Encode(),
-    InternalKey("00150000", 8000, kTypeValue).Encode(),
-    InternalKey("00150000", 3010, kTypeValue).Encode(),
-    InternalKey("00150000", 2500, kTypeValue).Encode(),
-    InternalKey("00150000", 1010, kTypeValue).Encode(),
-    InternalKey("08701234", 114514, kTypeValue).Encode(),
-    InternalKey("08701234", 8310, kTypeValue).Encode(),
-    InternalKey("08701234", 7210, kTypeValue).Encode(),
-    InternalKey("08701234", 690, kTypeValue).Encode(),
-    InternalKey("08701234", 69, kTypeValue).Encode(),
-    InternalKey("08701234", 0, kTypeValue).Encode(),
+  std::vector<InternalKey> seek_keys = {
+    InternalKey("00150000", 10000, kTypeValue),
+    InternalKey("00150000", 9990, kTypeValue),
+    InternalKey("00150000", 9010, kTypeValue),
+    InternalKey("00150000", 9000, kTypeValue),
+    InternalKey("00150000", 8990, kTypeValue),
+    InternalKey("00150000", 8000, kTypeValue),
+    InternalKey("00150000", 3010, kTypeValue),
+    InternalKey("00150000", 2500, kTypeValue),
+    InternalKey("00150000", 1010, kTypeValue),
+    InternalKey("08701234", 114514, kTypeValue),
+    InternalKey("08701234", 8310, kTypeValue),
+    InternalKey("08701234", 7210, kTypeValue),
+    InternalKey("08701234", 1690, kTypeValue),
+    InternalKey("08701234", 69, kTypeValue),
+    InternalKey("08701234", 0, kTypeValue),
   };
   std::vector<std::string> sk_answers = {
     data_block_values[1], data_block_values[2], data_block_values[2], 
     data_block_values[2], data_block_values[3], data_block_values[3],
     data_block_values[8], data_block_values[9], data_block_values[10],
     data_block_values[19], data_block_values[21], data_block_values[22],
-    data_block_values[29], std::string(""), std::string(""),
+    data_block_values[28], data_block_values[29], data_block_values[29],
   };
   for (size_t i = 0; i < seek_keys.size(); ++i) {
-    index_iter->Seek(seek_keys[i]);
+    index_iter->Seek(seek_keys[i].Encode());
 
-    if (i == 13 || i == 14) {
-      ASSERT_TRUE(!index_iter->Valid());
-      continue;
-    }
-    
     ASSERT_OK(index_iter->status());
     ASSERT_TRUE(index_iter->Valid());
 


### PR DESCRIPTION
Now stress test can run correctly in the following cases:
- `Get()` & `MultiGet()` with iterator workload and overwriting enabled, in NonBatched test:
`make clean && export CRASH_TEST_EXT_ARGS="--index_type=4 --plr_index_block_gamma=1 --max_key_len=1 --key_len_percent_dist=100 --index_block_restart_interval=1 --readpercent=30 --prefixpercent=0 --writepercent=30 --delpercent=5 --delrangepercent=5 --iterpercent=30 --statistics --test_batches_snapshots=0" && make crash_test -j`

- `Get()` with iterator workload and overwriting enabled in Batched test:
`make clean && export CRASH_TEST_EXT_ARGS="--index_type=4 --plr_index_block_gamma=1 --max_key_len=1 --key_len_percent_dist=100 --index_block_restart_interval=1 --readpercent=20 --prefixpercent=0 --writepercent=30 --delpercent=10 --delrangepercent=10 --iterpercent=30 --statistics --test_batches_snapshots=1 --prefix_size=1 --use_multiget=0" && make crash_test -j`

However, it fails in:
- `MultiGet()` in Batched test:
`make clean && export CRASH_TEST_EXT_ARGS="--index_type=4 --plr_index_block_gamma=1 --max_key_len=1 --key_len_percent_dist=100 --index_block_restart_interval=1 --readpercent=20 --prefixpercent=0 --writepercent=30 --delpercent=10 --delrangepercent=10 --iterpercent=30 --statistics --test_batches_snapshots=0 --use_multiget=1" && make blackbox_crash_test -j`

Note that the `Key()` function in stress test is modified to suit our constraint on key size. In the test, the key range tested is [1..100000000].